### PR TITLE
Updated e2e script to better handle focus and skip

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -46,6 +46,8 @@ function run_test {
   bin/hydrophone \
     --output-dir ${ARTIFACTS}/results/ \
     --conformance-image registry.k8s.io/conformance:${K8S_VERSION} \
+    --focus "${FOCUS}" \
+    --skip "${SKIP}" \
     $EXTRA_ARGS| tee /tmp/test.log
   
   # Check if $CHECK_DURATION is set to true
@@ -93,9 +95,7 @@ fi
 
 # If CONFORMANCE is set, add --conformance to the EXTRA_ARGS
 if [[ ${CONFORMANCE} == "true" ]]; then
-  EXTRA_ARGS="${EXTRA_ARGS} --conformance"
-else 
-  EXTRA_ARGS="${EXTRA_ARGS} --focus ${FOCUS} --skip ${SKIP}"
+  FOCUS="\\[Conformance\\]"
 fi
 
 setup_kind


### PR DESCRIPTION
This should help resolve an issue where focus is being passed without a focus set. 

ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/hydrophone-e2e-check/1747986869506805760#1:build-log.txt%3A110-138