### PR TITLE
Adding evaluation for number of tests

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -67,6 +67,21 @@ function run_test {
       fi
     fi
   fi  
+
+  # If EXPECTED_NUM_TESTS is set, run the evaluate_test_num function
+  if [[ ! -z ${EXPECTED_NUM_TESTS+x} ]]; then
+    evaluate_test_num
+  fi
+}
+
+function evaluate_test_num {
+  NUM_TESTS=$(grep -oP 'Ran \K\d+(?= of \d+ Specs)' /tmp/test.log)
+
+  # Check if NUM_TESTS is not equal to EXPECTED_NUM_TESTS
+  if [[ ${NUM_TESTS} -ne ${EXPECTED_NUM_TESTS} ]]; then
+    echo "Expected ${EXPECTED_NUM_TESTS} tests, got ${NUM_TESTS} tests"
+    exit 1
+  fi
 }
 
 # Default versions k8s and kind


### PR DESCRIPTION
This change adds a check for the number of tests that are expected to run during any given job. For example, several times while updating the script I would make a change and instead of 1 spec running, there would be 19 specs ran. With this validation we'll be able to explicitly expect a certain number of tests to run. 