### PR TITLE
Remove redundant error check in  client.PrintE2ELogs()

### DIFF
--- a/pkg/client/check.go
+++ b/pkg/client/check.go
@@ -60,9 +60,6 @@ func (c *Client) PrintE2ELogs() {
 			}
 
 			go getPodLogs(c.ClientSet, stream)
-			if err != nil {
-				log.Fatal(err)
-			}
 
 		loop:
 			for {


### PR DESCRIPTION
Fix https://github.com/kubernetes-sigs/hydrophone/issues/123