### PR TITLE
fix: typo and copyright

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,7 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "hydrohpone",
+	Use:   "hydrophone",
 	Short: "Hydrophone is a lightweight runner for kubernetes tests.",
 	Long:  `Hydrophone is a lightweight runner for kubernetes tests.`,
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Fixes a typo and adds copyright in `cmd/root.go` 