### PR TITLE
Throw fatal error and ask user to run cleanup when a k8s resource already exists in the cluster

### DIFF
--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -171,10 +171,6 @@ func RunE2E(clientset *kubernetes.Clientset) {
 							Name:  "E2E_USE_GO_RUNNER",
 							Value: "true",
 						},
-						{
-							Name:  "E2E_EXTRA_ARGS",
-							Value: fmt.Sprintf("%s", viper.Get("E2E_EXTRA_ARGS")),
-						},
 					},
 					VolumeMounts: []v1.VolumeMount{
 						{

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -208,27 +208,27 @@ func RunE2E(clientset *kubernetes.Clientset) {
 		conformancePod.Spec.Containers[0].Env = append(conformancePod.Spec.Containers[0].Env, DryRun())
 	}
 
-	_, err := clientset.CoreV1().Namespaces().Create(ctx, &conformanceNS, metav1.CreateOptions{})
+	ns, err := clientset.CoreV1().Namespaces().Create(ctx, &conformanceNS, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("namespace already exist %s", conformanceNS.ObjectMeta.Name)
+			log.Fatalf("namespace already exist %s. Please run cleanup to start a fresh run", conformanceNS.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("namespace created %s\n", conformanceNS.ObjectMeta.Name)
+	log.Printf("namespace created %s\n", ns.Name)
 
-	_, err = clientset.CoreV1().ServiceAccounts(conformanceNS.ObjectMeta.Name).Create(ctx, &conformanceSA, metav1.CreateOptions{})
+	sa, err := clientset.CoreV1().ServiceAccounts(ns.Name).Create(ctx, &conformanceSA, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("serviceaccount already exist %s", conformanceSA.ObjectMeta.Name)
+			log.Fatalf("serviceaccount already exist %s. Please run cleanup to start a fresh run", conformanceSA.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("serviceaccount created %s\n", conformanceSA.ObjectMeta.Name)
+	log.Printf("serviceaccount created %s\n", sa.Name)
 
-	_, err = clientset.RbacV1().ClusterRoles().Create(ctx, &conformanceClusterRole, metav1.CreateOptions{})
+	clusterRole, err := clientset.RbacV1().ClusterRoles().Create(ctx, &conformanceClusterRole, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
 			log.Printf("clusterrole already exist %s", conformanceClusterRole.ObjectMeta.Name)
@@ -236,9 +236,9 @@ func RunE2E(clientset *kubernetes.Clientset) {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("clusterrole created %s\n", conformanceClusterRole.ObjectMeta.Name)
+	log.Printf("clusterrole created %s\n", clusterRole.Name)
 
-	_, err = clientset.RbacV1().ClusterRoleBindings().Create(ctx, &conformanceClusterRoleBinding, metav1.CreateOptions{})
+	clusterRoleBinding, err := clientset.RbacV1().ClusterRoleBindings().Create(ctx, &conformanceClusterRoleBinding, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
 			log.Printf("clusterrolebinding already exist %s", conformanceClusterRoleBinding.ObjectMeta.Name)
@@ -246,7 +246,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("clusterrolebinding created %s\n", conformanceClusterRoleBinding.ObjectMeta.Name)
+	log.Printf("clusterrolebinding created %s\n", clusterRoleBinding.Name)
 
 	if viper.GetString("test-repo-list") != "" {
 		RepoListData, err := os.ReadFile(viper.GetString("test-repo-list"))
@@ -287,15 +287,15 @@ func RunE2E(clientset *kubernetes.Clientset) {
 			Value: "/tmp/repo-list/repo-list.yaml",
 		})
 
-		_, err = clientset.CoreV1().ConfigMaps(conformanceNS.ObjectMeta.Name).Create(ctx, configMap, metav1.CreateOptions{})
+		configmap, err := clientset.CoreV1().ConfigMaps(ns.Name).Create(ctx, configMap, metav1.CreateOptions{})
 		if err != nil {
 			if errors.IsAlreadyExists(err) {
-				log.Printf("configmap already exists %s", configMap.ObjectMeta.Name)
+				log.Fatalf("configmap already exists %s. Please run cleanup to start a fresh run", configMap.ObjectMeta.Name)
 			} else {
 				log.Fatal(err)
 			}
 		}
-		log.Printf("configmap created %s\n", configMap.ObjectMeta.Name)
+		log.Printf("configmap created %s\n", configmap.Name)
 	}
 
 	if viper.GetString("test-repo") != "" {
@@ -305,10 +305,10 @@ func RunE2E(clientset *kubernetes.Clientset) {
 		})
 	}
 
-	_, err = clientset.CoreV1().Pods(conformanceNS.ObjectMeta.Name).Create(ctx, &conformancePod, metav1.CreateOptions{})
+	_, err = clientset.CoreV1().Pods(ns.Name).Create(ctx, &conformancePod, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("pod already exist %s", conformancePod.ObjectMeta.Name)
+			log.Fatalf("pod already exist %s. Please run cleanup to start a fresh run", conformancePod.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -211,7 +211,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 	ns, err := clientset.CoreV1().Namespaces().Create(ctx, &conformanceNS, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Fatalf("namespace already exist %s. Please run cleanup to start a fresh run", conformanceNS.ObjectMeta.Name)
+			log.Fatalf("namespace already exist %s. Please run cleanup first", conformanceNS.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}
@@ -221,7 +221,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 	sa, err := clientset.CoreV1().ServiceAccounts(ns.Name).Create(ctx, &conformanceSA, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Fatalf("serviceaccount already exist %s. Please run cleanup to start a fresh run", conformanceSA.ObjectMeta.Name)
+			log.Fatalf("serviceaccount already exist %s. Please run cleanup first", conformanceSA.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}
@@ -290,7 +290,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 		cm, err := clientset.CoreV1().ConfigMaps(ns.Name).Create(ctx, configMap, metav1.CreateOptions{})
 		if err != nil {
 			if errors.IsAlreadyExists(err) {
-				log.Fatalf("configmap already exists %s. Please run cleanup to start a fresh run", configMap.ObjectMeta.Name)
+				log.Fatalf("configmap already exists %s. Please run cleanup first", configMap.ObjectMeta.Name)
 			} else {
 				log.Fatal(err)
 			}
@@ -308,7 +308,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 	pod, err := clientset.CoreV1().Pods(ns.Name).Create(ctx, &conformancePod, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Fatalf("pod already exist %s. Please run cleanup to start a fresh run", conformancePod.ObjectMeta.Name)
+			log.Fatalf("pod already exist %s. Please run cleanup first", conformancePod.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -287,7 +287,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 			Value: "/tmp/repo-list/repo-list.yaml",
 		})
 
-		configmap, err := clientset.CoreV1().ConfigMaps(ns.Name).Create(ctx, configMap, metav1.CreateOptions{})
+		cm, err := clientset.CoreV1().ConfigMaps(ns.Name).Create(ctx, configMap, metav1.CreateOptions{})
 		if err != nil {
 			if errors.IsAlreadyExists(err) {
 				log.Fatalf("configmap already exists %s. Please run cleanup to start a fresh run", configMap.ObjectMeta.Name)
@@ -295,7 +295,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 				log.Fatal(err)
 			}
 		}
-		log.Printf("configmap created %s\n", configmap.Name)
+		log.Printf("configmap created %s\n", cm.Name)
 	}
 
 	if viper.GetString("test-repo") != "" {
@@ -305,7 +305,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 		})
 	}
 
-	_, err = clientset.CoreV1().Pods(ns.Name).Create(ctx, &conformancePod, metav1.CreateOptions{})
+	pod, err := clientset.CoreV1().Pods(ns.Name).Create(ctx, &conformancePod, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
 			log.Fatalf("pod already exist %s. Please run cleanup to start a fresh run", conformancePod.ObjectMeta.Name)
@@ -313,7 +313,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("pod created %s\n", conformancePod.ObjectMeta.Name)
+	log.Printf("pod created %s\n", pod.Name)
 }
 
 // Cleanup removes all resources created during E2E tests.

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -171,6 +171,10 @@ func RunE2E(clientset *kubernetes.Clientset) {
 							Name:  "E2E_USE_GO_RUNNER",
 							Value: "true",
 						},
+						{
+							Name:  "E2E_EXTRA_ARGS",
+							Value: fmt.Sprintf("%s", viper.Get("E2E_EXTRA_ARGS")),
+						},
 					},
 					VolumeMounts: []v1.VolumeMount{
 						{
@@ -208,45 +212,45 @@ func RunE2E(clientset *kubernetes.Clientset) {
 		conformancePod.Spec.Containers[0].Env = append(conformancePod.Spec.Containers[0].Env, DryRun())
 	}
 
-	ns, err := clientset.CoreV1().Namespaces().Create(ctx, &conformanceNS, metav1.CreateOptions{})
+	_, err := clientset.CoreV1().Namespaces().Create(ctx, &conformanceNS, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("namespace already exist %s", common.PodName)
+			log.Printf("namespace already exist %s", conformanceNS.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("namespace created %s\n", ns.Name)
+	log.Printf("namespace created %s\n", conformanceNS.ObjectMeta.Name)
 
-	sa, err := clientset.CoreV1().ServiceAccounts(ns.Name).Create(ctx, &conformanceSA, metav1.CreateOptions{})
+	_, err = clientset.CoreV1().ServiceAccounts(conformanceNS.ObjectMeta.Name).Create(ctx, &conformanceSA, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("serviceaccount already exist %s", common.PodName)
+			log.Printf("serviceaccount already exist %s", conformanceSA.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("serviceaccount created %s\n", sa.Name)
+	log.Printf("serviceaccount created %s\n", conformanceSA.ObjectMeta.Name)
 
-	clusterRole, err := clientset.RbacV1().ClusterRoles().Create(ctx, &conformanceClusterRole, metav1.CreateOptions{})
+	_, err = clientset.RbacV1().ClusterRoles().Create(ctx, &conformanceClusterRole, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("clusterrole already exist %s", common.PodName)
+			log.Printf("clusterrole already exist %s", conformanceClusterRole.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("clusterrole created %s\n", clusterRole.Name)
+	log.Printf("clusterrole created %s\n", conformanceClusterRole.ObjectMeta.Name)
 
-	clusterRoleBinding, err := clientset.RbacV1().ClusterRoleBindings().Create(ctx, &conformanceClusterRoleBinding, metav1.CreateOptions{})
+	_, err = clientset.RbacV1().ClusterRoleBindings().Create(ctx, &conformanceClusterRoleBinding, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("clusterrolebinding already exist %s", common.PodName)
+			log.Printf("clusterrolebinding already exist %s", conformanceClusterRoleBinding.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("clusterrolebinding created %s\n", clusterRoleBinding.Name)
+	log.Printf("clusterrolebinding created %s\n", conformanceClusterRoleBinding.ObjectMeta.Name)
 
 	if viper.GetString("test-repo-list") != "" {
 		RepoListData, err := os.ReadFile(viper.GetString("test-repo-list"))
@@ -287,7 +291,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 			Value: "/tmp/repo-list/repo-list.yaml",
 		})
 
-		cm, err := clientset.CoreV1().ConfigMaps(common.Namespace).Create(ctx, configMap, metav1.CreateOptions{})
+		_, err = clientset.CoreV1().ConfigMaps(conformanceNS.ObjectMeta.Name).Create(ctx, configMap, metav1.CreateOptions{})
 		if err != nil {
 			if errors.IsAlreadyExists(err) {
 				log.Printf("configmap already exists %s", configMap.ObjectMeta.Name)
@@ -295,7 +299,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 				log.Fatal(err)
 			}
 		}
-		log.Printf("configmap created %s\n", cm.Name)
+		log.Printf("configmap created %s\n", configMap.ObjectMeta.Name)
 	}
 
 	if viper.GetString("test-repo") != "" {
@@ -305,15 +309,15 @@ func RunE2E(clientset *kubernetes.Clientset) {
 		})
 	}
 
-	pod, err := clientset.CoreV1().Pods(ns.Name).Create(ctx, &conformancePod, metav1.CreateOptions{})
+	_, err = clientset.CoreV1().Pods(conformanceNS.ObjectMeta.Name).Create(ctx, &conformancePod, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("pod already exist %s", common.PodName)
+			log.Printf("pod already exist %s", conformancePod.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("pod created %s\n", pod.Name)
+	log.Printf("pod created %s\n", conformancePod.ObjectMeta.Name)
 }
 
 // Cleanup removes all resources created during E2E tests.


### PR DESCRIPTION
When k8s resource like Namespace, clusterrole, clusterrole, binding, service account  already exists in the cluster the RunE2E() test fails because the Create() operation returns error. But the error in the logs are not clear. Throw Fatal error when resource already exists and ask to run cleanup

Eg: when namespace already exists in the cluster I am getting below error 
```
reeta@Reetas-MacBook-Pro hydrophone % make run
go run main.go
12:20:53 INF API endpoint : https://127.0.0.1:57154
12:20:53 INF Server version : version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.0", GitCommit:"4ce5a8954017644c5420bae81d72b09b735c21f0", GitTreeState:"clean", BuildDate:"2022-05-19T15:42:59Z", GoVersion:"go1.18.1", Compiler:"gc", Platform:"linux/arm64"}
12:20:53 INF Using conformance image : 'registry.k8s.io/conformance:v1.24.0'
12:20:53 INF Using busybox image : 'registry.k8s.io/e2e-test-images/busybox:1.36.1-1'
12:20:53 INF Test framework will start '1' threads and use verbosity '4'
12:20:53 INF namespace already exist e2e-conformance-test
12:20:53 INF namespace created 

12:20:53 ERR an empty namespace may not be set during creation
exit status 1
make: *** [run] Error 1

```

To recreate this failure run `make run` twice 


With this fix in place, it works fine
```
reeta@Reetas-MacBook-Pro hydrophone % make run
go run main.go
14:04:22 INF API endpoint : https://127.0.0.1:50108
14:04:22 INF Server version : version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.0", GitCommit:"4ce5a8954017644c5420bae81d72b09b735c21f0", GitTreeState:"clean", BuildDate:"2022-05-19T15:42:59Z", GoVersion:"go1.18.1", Compiler:"gc", Platform:"linux/arm64"}
14:04:22 INF Using conformance image : 'registry.k8s.io/conformance:v1.24.0'
14:04:22 INF Using busybox image : 'registry.k8s.io/e2e-test-images/busybox:1.36.1-1'
14:04:22 INF Test framework will start '1' threads and use verbosity '4'
14:04:22 ERR namespace already exist conformance. Please run cleanup to start a fresh run
exit status 1
make: *** [run] Error 1
reeta@Reetas-MacBook-Pro hydrophone % 
```