### PR TITLE
Add support for Additional Conformance Test Flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -129,7 +129,7 @@ func init() {
 	rootCmd.Flags().StringVar(&testRepo, "test-repo", "", "skip specific tests. allows regular expressions.")
 	viper.BindPFlag("test-repo", rootCmd.Flags().Lookup("test-repo"))
 
-	rootCmd.Flags().StringSlice("extra-args", []string{}, "Additional parameters to be provided to the conformance container. These parameters should be specified as key-value pairs, separated by commas. Each parameter should start with -- (e.g., --list-labels=true,allowed-not-ready-nodes=2)")
+	rootCmd.Flags().StringSlice("extra-args", []string{}, "Additional parameters to be provided to the conformance container. These parameters should be specified as key-value pairs, separated by commas. Each parameter should start with -- (e.g., --list-labels=true,--allowed-not-ready-nodes=2)")
 	viper.BindPFlag("extra-args", rootCmd.Flags().Lookup("extra-args"))
 
 	rootCmd.MarkFlagsMutuallyExclusive("conformance", "focus", "cleanup", "list-images")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -129,8 +129,8 @@ func init() {
 	rootCmd.Flags().StringVar(&testRepo, "test-repo", "", "skip specific tests. allows regular expressions.")
 	viper.BindPFlag("test-repo", rootCmd.Flags().Lookup("test-repo"))
 
-	rootCmd.Flags().StringSlice("extra-conformance-test-args", []string{}, "Additional parameters to be provided to the conformance container. These parameters should be specified as key-value pairs, separated by commas. Each parameter should start with -- (e.g., --list-labels=true,--allowed-not-ready-nodes=2)")
-	viper.BindPFlag("extra-conformance-test-args", rootCmd.Flags().Lookup("extra-conformance-test-args"))
+	rootCmd.Flags().StringSlice("extra-args", []string{}, "Additional parameters to be provided to the conformance container. These parameters should be specified as key-value pairs, separated by commas. Each parameter should start with -- (e.g., --clean-start=true,--allowed-not-ready-nodes=2)")
+	viper.BindPFlag("extra-args", rootCmd.Flags().Lookup("extra-args"))
 
 	rootCmd.MarkFlagsMutuallyExclusive("conformance", "focus", "cleanup", "list-images")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -129,6 +129,9 @@ func init() {
 	rootCmd.Flags().StringVar(&testRepo, "test-repo", "", "skip specific tests. allows regular expressions.")
 	viper.BindPFlag("test-repo", rootCmd.Flags().Lookup("test-repo"))
 
+	rootCmd.Flags().StringSlice("extra-args", []string{}, "Additional parameters to be provided to the conformance container. These parameters should be specified as key-value pairs, separated by commas. Each parameter should start with -- (e.g., --list-labels=true,allowed-not-ready-nodes=2)")
+	viper.BindPFlag("extra-args", rootCmd.Flags().Lookup("keyValue"))
+
 	rootCmd.MarkFlagsMutuallyExclusive("conformance", "focus", "cleanup", "list-images")
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -129,8 +129,8 @@ func init() {
 	rootCmd.Flags().StringVar(&testRepo, "test-repo", "", "skip specific tests. allows regular expressions.")
 	viper.BindPFlag("test-repo", rootCmd.Flags().Lookup("test-repo"))
 
-	rootCmd.Flags().StringSlice("extra-args", []string{}, "Additional parameters to be provided to the conformance container. These parameters should be specified as key-value pairs, separated by commas. Each parameter should start with -- (e.g., --list-labels=true,--allowed-not-ready-nodes=2)")
-	viper.BindPFlag("extra-args", rootCmd.Flags().Lookup("extra-args"))
+	rootCmd.Flags().StringSlice("extra-conformance-test-args", []string{}, "Additional parameters to be provided to the conformance container. These parameters should be specified as key-value pairs, separated by commas. Each parameter should start with -- (e.g., --list-labels=true,--allowed-not-ready-nodes=2)")
+	viper.BindPFlag("extra-conformance-test-args", rootCmd.Flags().Lookup("extra-conformance-test-args"))
 
 	rootCmd.MarkFlagsMutuallyExclusive("conformance", "focus", "cleanup", "list-images")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,7 +130,7 @@ func init() {
 	viper.BindPFlag("test-repo", rootCmd.Flags().Lookup("test-repo"))
 
 	rootCmd.Flags().StringSlice("extra-args", []string{}, "Additional parameters to be provided to the conformance container. These parameters should be specified as key-value pairs, separated by commas. Each parameter should start with -- (e.g., --list-labels=true,allowed-not-ready-nodes=2)")
-	viper.BindPFlag("extra-args", rootCmd.Flags().Lookup("keyValue"))
+	viper.BindPFlag("extra-args", rootCmd.Flags().Lookup("extra-args"))
 
 	rootCmd.MarkFlagsMutuallyExclusive("conformance", "focus", "cleanup", "list-images")
 }

--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -56,7 +56,7 @@ func ValidateArgs(clientSet *kubernetes.Clientset, config *rest.Config) {
 		log.Printf("Skipping tests : '%s'", viper.Get("skip"))
 	}
 
-	if extraArgs := viper.Get("extra-conformance-test-args"); extraArgs != "" {
+	if extraArgs := viper.Get("extra-args"); extraArgs != "" {
 		updatedExtraArgs := ""
 		extraArgsSeperator := " "
 		for _, kv := range extraArgs.([]string) {
@@ -71,7 +71,7 @@ func ValidateArgs(clientSet *kubernetes.Clientset, config *rest.Config) {
 			updatedExtraArgs = fmt.Sprintf("%s%s%s", updatedExtraArgs, extraArgsSeperator, kv)
 		}
 		updatedExtraArgs = strings.TrimPrefix(updatedExtraArgs, extraArgsSeperator)
-		viper.Set("extra-conformance-test-args", updatedExtraArgs)
+		viper.Set("extra-args", updatedExtraArgs)
 	}
 	log.Printf("Using conformance image : '%s'", viper.Get("conformance-image"))
 	log.Printf("Using busybox image : '%s'", viper.Get("busybox-image"))

--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -56,12 +56,12 @@ func ValidateArgs(clientSet *kubernetes.Clientset, config *rest.Config) {
 		log.Printf("Skipping tests : '%s'", viper.Get("skip"))
 	}
 
-	if extraArgs := viper.GetString("extra-args"); extraArgs != "" {
-		args := strings.Split(extraArgs, ",")
+	log.Printf("extra-args : '%s'", viper.Get("extra-args"))
+	if extraArgs := viper.Get("extra-args"); extraArgs != "" {
 		updatedExtraArgs := ""
 		// using space as seperator for extra args
 		extraArgsSeperator := " "
-		for _, kv := range args {
+		for _, kv := range extraArgs.([]string) {
 			keyValuePair := strings.SplitN(kv, "=", 2)
 			if len(keyValuePair) != 2 {
 				log.Fatalf("Expected [%s] in [%s] to be of --key=value format", keyValuePair, extraArgs)
@@ -72,7 +72,9 @@ func ValidateArgs(clientSet *kubernetes.Clientset, config *rest.Config) {
 			}
 			updatedExtraArgs = fmt.Sprintf("%s%s%s", updatedExtraArgs, extraArgsSeperator, kv)
 		}
+		updatedExtraArgs = strings.TrimPrefix(updatedExtraArgs, extraArgsSeperator)
 		viper.Set("extra-args", updatedExtraArgs)
+		log.Printf("extra-args : '%s'", viper.Get("extra-args"))
 	}
 	log.Printf("Using conformance image : '%s'", viper.Get("conformance-image"))
 	log.Printf("Using busybox image : '%s'", viper.Get("busybox-image"))

--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -55,17 +55,6 @@ func ValidateArgs(clientSet *kubernetes.Clientset, config *rest.Config) {
 	if viper.Get("skip") != "" {
 		log.Printf("Skipping tests : '%s'", viper.Get("skip"))
 	}
-	log.Printf("Using conformance image : '%s'", viper.Get("conformance-image"))
-	log.Printf("Using busybox image : '%s'", viper.Get("busybox-image"))
-	log.Printf("Test framework will start '%d' threads and use verbosity '%d'",
-		viper.Get("parallel"), viper.Get("verbosity"))
-
-	outputDir := viper.GetString("output-dir")
-	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
-		if err = os.MkdirAll(outputDir, 0755); err != nil {
-			log.Fatalf("Error creating output directory [%s] : %v", outputDir, err)
-		}
-	}
 
 	if extraArgs := viper.GetString("extra-args"); extraArgs != "" {
 		args := strings.Split(extraArgs, ",")
@@ -85,4 +74,16 @@ func ValidateArgs(clientSet *kubernetes.Clientset, config *rest.Config) {
 		}
 		viper.Set("extra-args", updatedExtraArgs)
 	}
+	log.Printf("Using conformance image : '%s'", viper.Get("conformance-image"))
+	log.Printf("Using busybox image : '%s'", viper.Get("busybox-image"))
+	log.Printf("Test framework will start '%d' threads and use verbosity '%d'",
+		viper.Get("parallel"), viper.Get("verbosity"))
+
+	outputDir := viper.GetString("output-dir")
+	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+		if err = os.MkdirAll(outputDir, 0755); err != nil {
+			log.Fatalf("Error creating output directory [%s] : %v", outputDir, err)
+		}
+	}
+
 }

--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -56,10 +56,8 @@ func ValidateArgs(clientSet *kubernetes.Clientset, config *rest.Config) {
 		log.Printf("Skipping tests : '%s'", viper.Get("skip"))
 	}
 
-	log.Printf("extra-args : '%s'", viper.Get("extra-args"))
 	if extraArgs := viper.Get("extra-args"); extraArgs != "" {
 		updatedExtraArgs := ""
-		// using space as seperator for extra args
 		extraArgsSeperator := " "
 		for _, kv := range extraArgs.([]string) {
 			keyValuePair := strings.SplitN(kv, "=", 2)

--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -56,7 +56,7 @@ func ValidateArgs(clientSet *kubernetes.Clientset, config *rest.Config) {
 		log.Printf("Skipping tests : '%s'", viper.Get("skip"))
 	}
 
-	if extraArgs := viper.Get("extra-args"); extraArgs != "" {
+	if extraArgs := viper.Get("extra-conformance-test-args"); extraArgs != "" {
 		updatedExtraArgs := ""
 		extraArgsSeperator := " "
 		for _, kv := range extraArgs.([]string) {
@@ -71,8 +71,7 @@ func ValidateArgs(clientSet *kubernetes.Clientset, config *rest.Config) {
 			updatedExtraArgs = fmt.Sprintf("%s%s%s", updatedExtraArgs, extraArgsSeperator, kv)
 		}
 		updatedExtraArgs = strings.TrimPrefix(updatedExtraArgs, extraArgsSeperator)
-		viper.Set("extra-args", updatedExtraArgs)
-		log.Printf("extra-args : '%s'", viper.Get("extra-args"))
+		viper.Set("extra-conformance-test-args", updatedExtraArgs)
 	}
 	log.Printf("Using conformance image : '%s'", viper.Get("conformance-image"))
 	log.Printf("Using busybox image : '%s'", viper.Get("busybox-image"))

--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -19,6 +19,7 @@ package common
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/viper"
 	"k8s.io/client-go/kubernetes"
@@ -64,5 +65,22 @@ func ValidateArgs(clientSet *kubernetes.Clientset, config *rest.Config) {
 		if err = os.MkdirAll(outputDir, 0755); err != nil {
 			log.Fatalf("Error creating output directory [%s] : %v", outputDir, err)
 		}
+	}
+
+	if extraArgs := viper.GetString("extra-args"); extraArgs != "" {
+		args := strings.Split(extraArgs, ",")
+		updatedArgs := ""
+		for _, kv := range args {
+			keyValuePair := strings.SplitN(kv, "=", 2)
+			if len(keyValuePair) != 2 {
+				log.Fatalf("Expected [%s] in %s to be of --key=value format", keyValuePair, extraArgs)
+			}
+			key := keyValuePair[0]
+			if !strings.HasPrefix(key, "--") && strings.Count(key, "--") != 1 {
+				log.Fatalf("Expected key [%s] in %s to start with prefix --", keyValuePair[0], extraArgs)
+			}
+			updatedArgs = updatedArgs + kv + " "
+		}
+		viper.Set("extra-args", updatedArgs)
 	}
 }

--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -69,18 +69,20 @@ func ValidateArgs(clientSet *kubernetes.Clientset, config *rest.Config) {
 
 	if extraArgs := viper.GetString("extra-args"); extraArgs != "" {
 		args := strings.Split(extraArgs, ",")
-		updatedArgs := ""
+		updatedExtraArgs := ""
+		// using space as seperator for extra args
+		extraArgsSeperator := " "
 		for _, kv := range args {
 			keyValuePair := strings.SplitN(kv, "=", 2)
 			if len(keyValuePair) != 2 {
-				log.Fatalf("Expected [%s] in %s to be of --key=value format", keyValuePair, extraArgs)
+				log.Fatalf("Expected [%s] in [%s] to be of --key=value format", keyValuePair, extraArgs)
 			}
 			key := keyValuePair[0]
 			if !strings.HasPrefix(key, "--") && strings.Count(key, "--") != 1 {
-				log.Fatalf("Expected key [%s] in %s to start with prefix --", keyValuePair[0], extraArgs)
+				log.Fatalf("Expected key [%s] in [%s] to start with prefix --", key, extraArgs)
 			}
-			updatedArgs = updatedArgs + kv + " "
+			updatedExtraArgs = fmt.Sprintf("%s%s%s", updatedExtraArgs, extraArgsSeperator, kv)
 		}
-		viper.Set("extra-args", updatedArgs)
+		viper.Set("extra-args", updatedExtraArgs)
 	}
 }

--- a/pkg/common/args_test.go
+++ b/pkg/common/args_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/common/args_test.go
+++ b/pkg/common/args_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors.
+Copyright 2024 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/common/args_test.go
+++ b/pkg/common/args_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package common
 
 import (

--- a/pkg/common/args_test.go
+++ b/pkg/common/args_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package common
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestValidateArgs(t *testing.T) {
+	// Create a temporary output directory
+	tempDir := t.TempDir()
+	viper.Set("output-dir", tempDir)
+
+	// Set up the test cases
+	testCases := []struct {
+		name          string
+		focus         string
+		expectedFocus string
+		skip          string
+		expectedSkip  string
+		extraArgs     []string
+		expectedArgs  string
+	}{
+		{
+			name:          "With focus",
+			focus:         "\\[E2E\\]",
+			expectedFocus: "\\[E2E\\]",
+			skip:          "",
+			expectedSkip:  "",
+			extraArgs:     []string{},
+			expectedArgs:  "",
+		},
+		{
+			name:          "With skip",
+			focus:         "",
+			expectedFocus: "\\[Conformance\\]",
+			skip:          "some tests",
+			expectedSkip:  "some tests",
+			extraArgs:     []string{},
+			expectedArgs:  "",
+		},
+		{
+			name:          "With extra args",
+			focus:         "",
+			expectedFocus: "\\[Conformance\\]",
+			skip:          "",
+			expectedSkip:  "",
+			extraArgs:     []string{"--key1=value1", "--key2=value2"},
+			expectedArgs:  "--key1=value1 --key2=value2",
+		},
+	}
+
+	// Run the test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set up the test environment
+			viper.Set("focus", tc.focus)
+			viper.Set("skip", tc.skip)
+			viper.Set("extra-args", tc.extraArgs)
+
+			// Call the function under test
+			ValidateArgs(nil, nil)
+
+			// TODO: Add assertions for the expected log output and other side effects
+			if viper.GetString("skip") != tc.expectedSkip {
+				t.Errorf("expected skip to be [%s], got [%s]", tc.expectedSkip, viper.GetString("skip"))
+			}
+			if viper.GetString("focus") != tc.expectedFocus {
+				t.Errorf("expected focus to be [%s], got [%s]", tc.expectedFocus, viper.GetString("focus"))
+			}
+			if viper.GetString("extra-args") != tc.expectedArgs {
+				t.Errorf("expected extra-args to be [%s], got [%s]", tc.expectedArgs, viper.GetString("extra-args"))
+			}
+		})
+	}
+}

--- a/pkg/common/args_test.go
+++ b/pkg/common/args_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -71,7 +71,7 @@ func TestValidateArgs(t *testing.T) {
 			// Set up the test environment
 			viper.Set("focus", tc.focus)
 			viper.Set("skip", tc.skip)
-			viper.Set("extra-conformance-test-args", tc.extraArgs)
+			viper.Set("extra-args", tc.extraArgs)
 
 			// Call the function under test
 			ValidateArgs(nil, nil)
@@ -81,8 +81,8 @@ func TestValidateArgs(t *testing.T) {
 			if viper.GetString("focus") != tc.expectedFocus {
 				t.Errorf("expected focus to be [%s], got [%s]", tc.expectedFocus, viper.GetString("focus"))
 			}
-			if viper.GetString("extra-conformance-test-args") != tc.expectedArgs {
-				t.Errorf("expected extra-conformance-test-args to be [%s], got [%s]", tc.expectedArgs, viper.GetString("extra-conformance-test-args"))
+			if viper.GetString("extra-args") != tc.expectedArgs {
+				t.Errorf("expected extra-args to be [%s], got [%s]", tc.expectedArgs, viper.GetString("extra-args"))
 			}
 		})
 	}

--- a/pkg/common/args_test.go
+++ b/pkg/common/args_test.go
@@ -71,20 +71,18 @@ func TestValidateArgs(t *testing.T) {
 			// Set up the test environment
 			viper.Set("focus", tc.focus)
 			viper.Set("skip", tc.skip)
-			viper.Set("extra-args", tc.extraArgs)
+			viper.Set("extra-conformance-test-args", tc.extraArgs)
 
 			// Call the function under test
 			ValidateArgs(nil, nil)
-
-			// TODO: Add assertions for the expected log output and other side effects
 			if viper.GetString("skip") != tc.expectedSkip {
 				t.Errorf("expected skip to be [%s], got [%s]", tc.expectedSkip, viper.GetString("skip"))
 			}
 			if viper.GetString("focus") != tc.expectedFocus {
 				t.Errorf("expected focus to be [%s], got [%s]", tc.expectedFocus, viper.GetString("focus"))
 			}
-			if viper.GetString("extra-args") != tc.expectedArgs {
-				t.Errorf("expected extra-args to be [%s], got [%s]", tc.expectedArgs, viper.GetString("extra-args"))
+			if viper.GetString("extra-conformance-test-args") != tc.expectedArgs {
+				t.Errorf("expected extra-conformance-test-args to be [%s], got [%s]", tc.expectedArgs, viper.GetString("extra-conformance-test-args"))
 			}
 		})
 	}

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors.
+Copyright 2024 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -173,7 +173,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 						},
 						{
 							Name:  "E2E_EXTRA_ARGS",
-							Value: fmt.Sprintf("%s", viper.Get("extra-args")),
+							Value: fmt.Sprintf("%s", viper.Get("extra-conformance-test-args")),
 						},
 					},
 					VolumeMounts: []v1.VolumeMount{

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -212,45 +212,45 @@ func RunE2E(clientset *kubernetes.Clientset) {
 		conformancePod.Spec.Containers[0].Env = append(conformancePod.Spec.Containers[0].Env, DryRun())
 	}
 
-	ns, err := clientset.CoreV1().Namespaces().Create(ctx, &conformanceNS, metav1.CreateOptions{})
+	_, err := clientset.CoreV1().Namespaces().Create(ctx, &conformanceNS, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("namespace already exist %s", common.PodName)
+			log.Printf("namespace already exist %s", conformanceNS.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("namespace created %s\n", ns.Name)
+	log.Printf("namespace created %s\n", conformanceNS.ObjectMeta.Name)
 
-	sa, err := clientset.CoreV1().ServiceAccounts(ns.Name).Create(ctx, &conformanceSA, metav1.CreateOptions{})
+	_, err = clientset.CoreV1().ServiceAccounts(conformanceNS.ObjectMeta.Name).Create(ctx, &conformanceSA, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("serviceaccount already exist %s", common.PodName)
+			log.Printf("serviceaccount already exist %s", conformanceSA.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("serviceaccount created %s\n", sa.Name)
+	log.Printf("serviceaccount created %s\n", conformanceSA.ObjectMeta.Name)
 
-	clusterRole, err := clientset.RbacV1().ClusterRoles().Create(ctx, &conformanceClusterRole, metav1.CreateOptions{})
+	_, err = clientset.RbacV1().ClusterRoles().Create(ctx, &conformanceClusterRole, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("clusterrole already exist %s", common.PodName)
+			log.Printf("clusterrole already exist %s", conformanceClusterRole.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("clusterrole created %s\n", clusterRole.Name)
+	log.Printf("clusterrole created %s\n", conformanceClusterRole.ObjectMeta.Name)
 
-	clusterRoleBinding, err := clientset.RbacV1().ClusterRoleBindings().Create(ctx, &conformanceClusterRoleBinding, metav1.CreateOptions{})
+	_, err = clientset.RbacV1().ClusterRoleBindings().Create(ctx, &conformanceClusterRoleBinding, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("clusterrolebinding already exist %s", common.PodName)
+			log.Printf("clusterrolebinding already exist %s", conformanceClusterRoleBinding.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("clusterrolebinding created %s\n", clusterRoleBinding.Name)
+	log.Printf("clusterrolebinding created %s\n", conformanceClusterRoleBinding.ObjectMeta.Name)
 
 	if viper.GetString("test-repo-list") != "" {
 		RepoListData, err := os.ReadFile(viper.GetString("test-repo-list"))
@@ -291,7 +291,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 			Value: "/tmp/repo-list/repo-list.yaml",
 		})
 
-		cm, err := clientset.CoreV1().ConfigMaps(common.Namespace).Create(ctx, configMap, metav1.CreateOptions{})
+		_, err = clientset.CoreV1().ConfigMaps(conformanceNS.ObjectMeta.Name).Create(ctx, configMap, metav1.CreateOptions{})
 		if err != nil {
 			if errors.IsAlreadyExists(err) {
 				log.Printf("configmap already exists %s", configMap.ObjectMeta.Name)
@@ -299,7 +299,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 				log.Fatal(err)
 			}
 		}
-		log.Printf("configmap created %s\n", cm.Name)
+		log.Printf("configmap created %s\n", configMap.ObjectMeta.Name)
 	}
 
 	if viper.GetString("test-repo") != "" {
@@ -309,15 +309,15 @@ func RunE2E(clientset *kubernetes.Clientset) {
 		})
 	}
 
-	pod, err := clientset.CoreV1().Pods(ns.Name).Create(ctx, &conformancePod, metav1.CreateOptions{})
+	_, err = clientset.CoreV1().Pods(conformanceNS.ObjectMeta.Name).Create(ctx, &conformancePod, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("pod already exist %s", common.PodName)
+			log.Printf("pod already exist %s", conformancePod.ObjectMeta.Name)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("pod created %s\n", pod.Name)
+	log.Printf("pod created %s\n", conformancePod.ObjectMeta.Name)
 }
 
 // Cleanup removes all resources created during E2E tests.

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -171,6 +171,10 @@ func RunE2E(clientset *kubernetes.Clientset) {
 							Name:  "E2E_USE_GO_RUNNER",
 							Value: "true",
 						},
+						{
+							Name:  "E2E_EXTRA_ARGS",
+							Value: fmt.Sprintf("%s", viper.Get("E2E_EXTRA_ARGS")),
+						},
 					},
 					VolumeMounts: []v1.VolumeMount{
 						{

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -173,7 +173,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 						},
 						{
 							Name:  "E2E_EXTRA_ARGS",
-							Value: fmt.Sprintf("%s", viper.Get("extra-conformance-test-args")),
+							Value: fmt.Sprintf("%s", viper.Get("extra-args")),
 						},
 					},
 					VolumeMounts: []v1.VolumeMount{

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -173,7 +173,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 						},
 						{
 							Name:  "E2E_EXTRA_ARGS",
-							Value: fmt.Sprintf("%s", viper.Get("E2E_EXTRA_ARGS")),
+							Value: fmt.Sprintf("%s", viper.Get("extra-args")),
 						},
 					},
 					VolumeMounts: []v1.VolumeMount{

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -212,45 +212,45 @@ func RunE2E(clientset *kubernetes.Clientset) {
 		conformancePod.Spec.Containers[0].Env = append(conformancePod.Spec.Containers[0].Env, DryRun())
 	}
 
-	_, err := clientset.CoreV1().Namespaces().Create(ctx, &conformanceNS, metav1.CreateOptions{})
+	ns, err := clientset.CoreV1().Namespaces().Create(ctx, &conformanceNS, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("namespace already exist %s", conformanceNS.ObjectMeta.Name)
+			log.Printf("namespace already exist %s", common.PodName)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("namespace created %s\n", conformanceNS.ObjectMeta.Name)
+	log.Printf("namespace created %s\n", ns.Name)
 
-	_, err = clientset.CoreV1().ServiceAccounts(conformanceNS.ObjectMeta.Name).Create(ctx, &conformanceSA, metav1.CreateOptions{})
+	sa, err := clientset.CoreV1().ServiceAccounts(ns.Name).Create(ctx, &conformanceSA, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("serviceaccount already exist %s", conformanceSA.ObjectMeta.Name)
+			log.Printf("serviceaccount already exist %s", common.PodName)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("serviceaccount created %s\n", conformanceSA.ObjectMeta.Name)
+	log.Printf("serviceaccount created %s\n", sa.Name)
 
-	_, err = clientset.RbacV1().ClusterRoles().Create(ctx, &conformanceClusterRole, metav1.CreateOptions{})
+	clusterRole, err := clientset.RbacV1().ClusterRoles().Create(ctx, &conformanceClusterRole, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("clusterrole already exist %s", conformanceClusterRole.ObjectMeta.Name)
+			log.Printf("clusterrole already exist %s", common.PodName)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("clusterrole created %s\n", conformanceClusterRole.ObjectMeta.Name)
+	log.Printf("clusterrole created %s\n", clusterRole.Name)
 
-	_, err = clientset.RbacV1().ClusterRoleBindings().Create(ctx, &conformanceClusterRoleBinding, metav1.CreateOptions{})
+	clusterRoleBinding, err := clientset.RbacV1().ClusterRoleBindings().Create(ctx, &conformanceClusterRoleBinding, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("clusterrolebinding already exist %s", conformanceClusterRoleBinding.ObjectMeta.Name)
+			log.Printf("clusterrolebinding already exist %s", common.PodName)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("clusterrolebinding created %s\n", conformanceClusterRoleBinding.ObjectMeta.Name)
+	log.Printf("clusterrolebinding created %s\n", clusterRoleBinding.Name)
 
 	if viper.GetString("test-repo-list") != "" {
 		RepoListData, err := os.ReadFile(viper.GetString("test-repo-list"))
@@ -291,7 +291,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 			Value: "/tmp/repo-list/repo-list.yaml",
 		})
 
-		_, err = clientset.CoreV1().ConfigMaps(conformanceNS.ObjectMeta.Name).Create(ctx, configMap, metav1.CreateOptions{})
+		cm, err := clientset.CoreV1().ConfigMaps(common.Namespace).Create(ctx, configMap, metav1.CreateOptions{})
 		if err != nil {
 			if errors.IsAlreadyExists(err) {
 				log.Printf("configmap already exists %s", configMap.ObjectMeta.Name)
@@ -299,7 +299,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 				log.Fatal(err)
 			}
 		}
-		log.Printf("configmap created %s\n", configMap.ObjectMeta.Name)
+		log.Printf("configmap created %s\n", cm.Name)
 	}
 
 	if viper.GetString("test-repo") != "" {
@@ -309,15 +309,15 @@ func RunE2E(clientset *kubernetes.Clientset) {
 		})
 	}
 
-	_, err = clientset.CoreV1().Pods(conformanceNS.ObjectMeta.Name).Create(ctx, &conformancePod, metav1.CreateOptions{})
+	pod, err := clientset.CoreV1().Pods(ns.Name).Create(ctx, &conformancePod, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.Printf("pod already exist %s", conformancePod.ObjectMeta.Name)
+			log.Printf("pod already exist %s", common.PodName)
 		} else {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("pod created %s\n", conformancePod.ObjectMeta.Name)
+	log.Printf("pod created %s\n", pod.Name)
 }
 
 // Cleanup removes all resources created during E2E tests.


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/hydrophone/issues/95

verified run by passing additional flags

```
reeta@Reetas-MacBook-Pro hydrophone % go run main.go --extra-args="--list-conformance-tests=true,--allowed-not-ready-nodes=2"
23:12:36 INF API endpoint : https://127.0.0.1:50108
23:12:36 INF Server version : version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.0", GitCommit:"4ce5a8954017644c5420bae81d72b09b735c21f0", GitTreeState:"clean", BuildDate:"2022-05-19T15:42:59Z", GoVersion:"go1.18.1", Compiler:"gc", Platform:"linux/arm64"}
23:12:36 INF Using conformance image : 'registry.k8s.io/conformance:v1.24.0'
23:12:36 INF Using busybox image : 'registry.k8s.io/e2e-test-images/busybox:1.36.1-1'
23:12:36 INF Test framework will start '1' threads and use verbosity '4'
23:12:36 INF namespace created conformance

23:12:36 INF serviceaccount created conformance-serviceaccount

23:12:36 INF clusterrole created conformance-serviceaccount

23:12:36 INF clusterrolebinding created conformance-serviceaccount-role

23:12:36 INF pod created e2e-conformance-test

sep is " " args are "--list-conformance-tests=true --allowed-not-ready-nodes=2"split [--list-conformance-tests=true --allowed-not-ready-nodes=2]
2024/01/28 07:12:36 Running command:
Command env: []
Run from directory: 
Executable path: /usr/local/bin/ginkgo
Args (comma-delimited): /usr/local/bin/ginkgo,--focus=\[Conformance\],--skip=,--noColor=true,/usr/local/bin/e2e.test,--,--disable-log-dump,--repo-root=/kubernetes,--provider=skeleton,--report-dir=/tmp/results,--kubeconfig=,--list-conformance-tests=true,--allowed-not-ready-nodes=2
2024/01/28 07:12:36 Now listening for interrupts
- testname: Admission webhook, list mutating webhooks
  codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] listing
    mutating webhooks should work [Conformance]'
  description: Create 10 mutating webhook configurations, all with a label. Attempt
    to list the webhook configurations matching the label; all the created webhook
    configurations MUST be present. Attempt to create an object; the object MUST be
    mutated. Attempt to remove the webhook configurations matching the label with
    deletecollection; all webhook configurations MUST be deleted. Attempt to create
    an object; the object MUST NOT be mutated.
  release: v1.16
```