### PR TITLE
chore: Remove unneeded params passed to common.ValidateArgs function

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,7 +61,7 @@ var rootCmd = &cobra.Command{
 		} else if listImages {
 			service.PrintListImages(client.ClientSet)
 		} else {
-			common.ValidateArgs(client.ClientSet, config)
+			common.ValidateArgs()
 
 			service.RunE2E(client.ClientSet)
 			client.PrintE2ELogs()

--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -47,7 +47,7 @@ func PrintInfo(clientSet *kubernetes.Clientset, config *rest.Config) {
 
 // ValidateArgs validates the arguments passed to the program
 // and creates the output directory if it doesn't exist
-func ValidateArgs(clientSet *kubernetes.Clientset, config *rest.Config) {
+func ValidateArgs() {
 	if viper.Get("focus") == "" {
 		viper.Set("focus", "\\[Conformance\\]")
 	}

--- a/pkg/common/args_test.go
+++ b/pkg/common/args_test.go
@@ -75,7 +75,7 @@ func TestValidateArgs(t *testing.T) {
 			viper.Set("extra-args", tc.extraArgs)
 
 			// Call the function under test
-			ValidateArgs(nil, nil)
+			ValidateArgs()
 			if viper.GetString("skip") != tc.expectedSkip {
 				t.Errorf("expected skip to be [%s], got [%s]", tc.expectedSkip, viper.GetString("skip"))
 			}


### PR DESCRIPTION
ValidateArgs(clientSet *kubernetes.Clientset, config *rest.Config) is not using the 2 params. Remove them and fix the unit test