### PR TITLE
fix: Add correct type check when extra-args param is empty

### DIFF
--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -56,10 +56,10 @@ func ValidateArgs() {
 		log.Printf("Skipping tests : '%s'", viper.Get("skip"))
 	}
 
-	if extraArgs := viper.Get("extra-args"); extraArgs != "" {
+	if extraArgs := viper.GetStringSlice("extra-args"); len(extraArgs) != 0 {
 		updatedExtraArgs := ""
 		extraArgsSeperator := " "
-		for _, kv := range extraArgs.([]string) {
+		for _, kv := range extraArgs {
 			keyValuePair := strings.SplitN(kv, "=", 2)
 			if len(keyValuePair) != 2 {
 				log.Fatalf("Expected [%s] in [%s] to be of --key=value format", keyValuePair, extraArgs)


### PR DESCRIPTION
When Viper.Get("extra-args") is a slice of string variable when it binds to the corresposing cobra flag. when checking the value use Viper.GetStringSlice and check length of slice instead of iterating on a interface type