### PR TITLE
Separated file retrieval from conformance pod

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,7 @@ var rootCmd = &cobra.Command{
 
 			service.RunE2E(client.ClientSet)
 			client.PrintE2ELogs()
+			service.PullFiles(client.ClientSet)
 			client.FetchFiles(config, clientSet, viper.GetString("output-dir"))
 			client.FetchExitCode()
 			service.Cleanup(client.ClientSet)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -48,7 +48,7 @@ func (c *Client) FetchFiles(config *rest.Config, clientset *kubernetes.Clientset
 		log.Fatalf("unable to create e2e.log: %v\n", err)
 	}
 	defer e2eLogFile.Close()
-	err = downloadFile(config, clientset, viper.GetString("namespace"), common.PodName, common.OutputContainer, "/tmp/results/e2e.log", e2eLogFile)
+	err = downloadFile(config, clientset, viper.GetString("namespace"), common.RetrievalPodName, common.OutputContainer, "/tmp/results/e2e.log", e2eLogFile)
 	if err != nil {
 		log.Fatalf("unable to download e2e.log: %v\n", err)
 	}
@@ -58,7 +58,7 @@ func (c *Client) FetchFiles(config *rest.Config, clientset *kubernetes.Clientset
 		log.Fatalf("unable to create junit_01.xml: %v\n", err)
 	}
 	defer junitXMLFile.Close()
-	err = downloadFile(config, clientset, viper.GetString("namespace"), common.PodName, common.OutputContainer, "/tmp/results/junit_01.xml", junitXMLFile)
+	err = downloadFile(config, clientset, viper.GetString("namespace"), common.RetrievalPodName, common.OutputContainer, "/tmp/results/junit_01.xml", junitXMLFile)
 	if err != nil {
 		log.Fatalf("unable to download junit_01.xml: %v\n", err)
 	}

--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -18,13 +18,14 @@ package common
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/spf13/viper"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"os"
 	"sigs.k8s.io/hydrophone/pkg/log"
-	"strings"
-	"time"
 )
 
 // PrintInfo prints the information about the cluster

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -23,6 +23,8 @@ const (
 	DefaultNamespace = "conformance"
 	// PodName is the name of the conformance pod
 	PodName = "e2e-conformance-test"
+	// RetrievalPodName is the name of the pod used to retrieve the e2e logs
+	RetrievalPodName = "e2e-retrieval-pod"
 	// ClusterRoleBindingName is the name of the cluster role binding
 	ClusterRoleBindingName = "conformance-serviceaccount-role"
 	// ClusterRoleName is the name of the cluster role
@@ -33,4 +35,6 @@ const (
 	ConformanceContainer = "conformance-container"
 	// OutputContainer is the name of the busybox container
 	OutputContainer = "output-container"
+	// PVCName is the name of the PVC
+	PVCName = "conformance-pvc"
 )

--- a/pkg/service/pull_files.go
+++ b/pkg/service/pull_files.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"context"
+
+	"github.com/spf13/viper"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/hydrophone/pkg/common"
+	"sigs.k8s.io/hydrophone/pkg/log"
+)
+
+func PullFiles(clientset *kubernetes.Clientset) {
+
+	namespace := viper.GetString("namespace")
+
+	retrievalPod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.RetrievalPodName,
+			Namespace: namespace,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    common.OutputContainer,
+					Image:   viper.GetString("busybox-image"),
+					Command: []string{"/bin/sh", "-c", "sleep infinity"},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "output-volume",
+							MountPath: "/tmp/results",
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "output-volume",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: common.PVCName,
+						},
+					},
+				},
+			},
+			RestartPolicy:      v1.RestartPolicyNever,
+			ServiceAccountName: "conformance-serviceaccount",
+		},
+	}
+
+	pod, err := clientset.CoreV1().Pods(namespace).Create(ctx, &retrievalPod, metav1.CreateOptions{})
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			log.Fatalf("pod already exist %s. Please run cleanup first", retrievalPod.ObjectMeta.Name)
+		} else {
+			log.Fatal(err)
+		}
+	}
+	log.Printf("pod created %s\n", pod.Name)
+
+	// Wait for the pod to be running
+	watchOptions := metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", common.RetrievalPodName).String(),
+	}
+
+	watchInterface, err := clientset.CoreV1().Pods(namespace).Watch(context.Background(), watchOptions)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	log.Println("Waiting for pod to be running and ready...")
+	for event := range watchInterface.ResultChan() {
+		pod, ok := event.Object.(*v1.Pod)
+		if !ok {
+			continue
+		}
+
+		isRunningAndReady := pod.Status.Phase == v1.PodRunning
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue {
+				isRunningAndReady = isRunningAndReady && true
+				break
+			}
+		}
+
+		if isRunningAndReady {
+			break
+		}
+	}
+}


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/hydrophone/issues/96

This PR separates the output container from the conformance pod. This is done by:

1. Creating a PVC that's used to store the e2e.log and junit_01.xml files
2. Creating a new file retrieval pod that uses the busybox image (which is now remoted from the conformance pod)
3. Mounting that PVC as the output dir for the conformance pod and file retrieval pod

@dims, I'm making an assumption here that a conformant cluster will have a default storage class. Is that a safe assumption? 

/cc @dims @rakshitgondwal @reetasingh 