### PR TITLE
refactor: have a common method for setting defaults and move spinner call to root.go

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,7 +56,7 @@ var rootCmd = &cobra.Command{
 		client := client.NewClient()
 		config, clientSet := service.Init(viper.GetString("kubeconfig"))
 		client.ClientSet = clientSet
-		common.SetCommonDefaults(client.ClientSet, config)
+		common.SetDefaults(client.ClientSet, config)
 		if cleanup {
 			service.Cleanup(client.ClientSet)
 		} else if listImages {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,9 +66,12 @@ var rootCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 			spinner := common.NewSpinner(os.Stdout)
-			spinner.Start()
+
 			service.RunE2E(client.ClientSet)
+			spinner.Start()
+			// PrintE2ELogs is the most time consuming method
 			client.PrintE2ELogs()
+			spinner.Stop()
 			client.FetchFiles(config, clientSet, viper.GetString("output-dir"))
 			client.FetchExitCode()
 			service.Cleanup(client.ClientSet)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,11 +65,14 @@ var rootCmd = &cobra.Command{
 			if err := common.ValidateConformanceArgs(); err != nil {
 				log.Fatal(err)
 			}
+			spinner := common.NewSpinner(os.Stdout)
+			spinner.Start()
 			service.RunE2E(client.ClientSet)
 			client.PrintE2ELogs()
 			client.FetchFiles(config, clientSet, viper.GetString("output-dir"))
 			client.FetchExitCode()
 			service.Cleanup(client.ClientSet)
+			spinner.Stop()
 		}
 		log.Println("Exiting with code: ", client.ExitCode)
 		os.Exit(client.ExitCode)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,7 @@ var rootCmd = &cobra.Command{
 
 			service.RunE2E(client.ClientSet)
 			spinner.Start()
-			// PrintE2ELogs is the most time consuming method
+			// PrintE2ELogs is a long running method
 			client.PrintE2ELogs()
 			spinner.Stop()
 			client.FetchFiles(config, clientSet, viper.GetString("output-dir"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,17 +56,15 @@ var rootCmd = &cobra.Command{
 		client := client.NewClient()
 		config, clientSet := service.Init(viper.GetString("kubeconfig"))
 		client.ClientSet = clientSet
-		common.PrintInfo(client.ClientSet, config)
+		common.SetCommonDefaults(client.ClientSet, config)
 		if cleanup {
-			common.SetDefaultNamespace()
 			service.Cleanup(client.ClientSet)
 		} else if listImages {
 			service.PrintListImages(client.ClientSet)
 		} else {
-			if err := common.ValidateArgs(); err != nil {
+			if err := common.ValidateConformanceArgs(); err != nil {
 				log.Fatal(err)
 			}
-
 			service.RunE2E(client.ClientSet)
 			client.PrintE2ELogs()
 			client.FetchFiles(config, clientSet, viper.GetString("output-dir"))

--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -51,7 +51,7 @@ func SetDefaults(clientSet *kubernetes.Clientset, config *rest.Config) {
 	if viper.Get("namespace") == "" {
 		viper.Set("namespace", DefaultNamespace)
 	}
-	log.PrintfAPI("API endpoint : %s", config.Host)
+	log.Printf("API endpoint : %s", config.Host)
 	log.Printf("Server version : %#v", *serverVersion)
 	log.Printf("Using namespace : '%s'", viper.Get("namespace"))
 	log.Printf("Using conformance image : '%s'", viper.Get("conformance-image"))

--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -30,11 +30,7 @@ import (
 	"sigs.k8s.io/hydrophone/pkg/log"
 )
 
-// PrintInfo prints the information about the cluster
-func PrintInfo(clientSet *kubernetes.Clientset, config *rest.Config) {
-	spinner := NewSpinner(os.Stdout)
-	spinner.Start()
-
+func SetCommonDefaults(clientSet *kubernetes.Clientset, config *rest.Config) {
 	time.Sleep(2 * time.Second)
 	serverVersion, err := clientSet.ServerVersion()
 	if err != nil {
@@ -50,24 +46,20 @@ func PrintInfo(clientSet *kubernetes.Clientset, config *rest.Config) {
 	if viper.Get("busybox-image") == "" {
 		viper.Set("busybox-image", busyboxImage)
 	}
-
+	if viper.Get("namespace") == "" {
+		viper.Set("namespace", DefaultNamespace)
+	}
 	log.PrintfAPI("API endpoint : %s", config.Host)
 	log.Printf("Server version : %#v", *serverVersion)
+	log.Printf("Using namespace : '%s'", viper.Get("namespace"))
+	log.Printf("Using conformance image : '%s'", viper.Get("conformance-image"))
+	log.Printf("Using busybox image : '%s'", viper.Get("busybox-image"))
 }
 
-func SetDefaultNamespace() {
-	if viper.Get("namespace") == "" {
-		viper.Set("namespace", DefaultNamespace)
-	}
-}
-
-// ValidateArgs validates the arguments passed to the program
+// ValidateConformanceArgs validates the arguments passed to the program
 // and creates the output directory if it doesn't exist
+func ValidateConformanceArgs() error {
 
-func ValidateArgs() error {
-	if viper.Get("namespace") == "" {
-		viper.Set("namespace", DefaultNamespace)
-	}
 	if viper.Get("focus") == "" {
 		viper.Set("focus", "\\[Conformance\\]")
 	}
@@ -89,9 +81,6 @@ func ValidateArgs() error {
 		}
 	}
 
-	log.Printf("Using namespace : '%s'", viper.Get("namespace"))
-	log.Printf("Using conformance image : '%s'", viper.Get("conformance-image"))
-	log.Printf("Using busybox image : '%s'", viper.Get("busybox-image"))
 	log.Printf("Test framework will start '%d' threads and use verbosity '%d'",
 		viper.Get("parallel"), viper.Get("verbosity"))
 

--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -30,7 +30,9 @@ import (
 	"sigs.k8s.io/hydrophone/pkg/log"
 )
 
-func SetCommonDefaults(clientSet *kubernetes.Clientset, config *rest.Config) {
+// SetDefaults sets the default values for various configuration options used in the application.
+// Finally, it logs the API endpoint, server version, namespace, conformance image, and busybox image.
+func SetDefaults(clientSet *kubernetes.Clientset, config *rest.Config) {
 	time.Sleep(2 * time.Second)
 	serverVersion, err := clientSet.ServerVersion()
 	if err != nil {

--- a/pkg/common/args_test.go
+++ b/pkg/common/args_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidateArgs(t *testing.T) {
+func TestValidateConformanceArgs(t *testing.T) {
 	// Create a temporary output directory
 	tempDir := t.TempDir()
 	viper.Set("output-dir", tempDir)
@@ -93,7 +93,7 @@ func TestValidateArgs(t *testing.T) {
 			viper.Set("extra-args", tc.extraArgs)
 
 			// Call the function under test
-			err := ValidateArgs()
+			err := ValidateConformanceArgs()
 			if tc.wantErr {
 				assert.EqualError(t, err, tc.expectedErr)
 			} else {

--- a/pkg/log/logs.go
+++ b/pkg/log/logs.go
@@ -55,12 +55,6 @@ func Printf(format string, v ...any) {
 	slog.Info(fmt.Sprintf(format, v...))
 }
 
-// Print logs for API
-func PrintfAPI(format string, v ...interface{}) {
-	fmt.Print("\n")
-	slog.Info(fmt.Sprintf(format, v...))
-}
-
 // Println logs an info message from the given arguments.
 func Println(v ...any) {
 	slog.Info(fmt.Sprint(v...))


### PR DESCRIPTION
- introduce common.SetDefaults to set defaults which are common for "conformance", "focus", "cleanup", "list-images" options
- rename ValidateArgs() -> ValidateConformanceArgs() as this is more specific to conformance image flags
- move spinner call to root.go 