### PR TITLE
Prepend v to trimmedVersion

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -46,7 +46,6 @@ function run_test {
 
   bin/hydrophone \
     --output-dir ${ARTIFACTS}/results/ \
-    --conformance-image registry.k8s.io/conformance:${K8S_VERSION} \
     --focus "${FOCUS}" \
     --skip "${SKIP}" \
     $EXTRA_ARGS| tee /tmp/test.log
@@ -99,6 +98,7 @@ DRYRUN=${DRYRUN:-"false"}
 CONFORMANCE=${CONFORMANCE:-"false"}
 EXTRA_ARGS=${EXTRA_ARGS:-""}
 CHECK_DURATION=${CHECK_DURATION:-"false"}
+SET_VERSION=${SET_VERSION:-"false"}
 
 # Set the artifacts directory, defaulting to a local subdirectory
 export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
@@ -112,6 +112,11 @@ fi
 # If CONFORMANCE is set, add --conformance to the EXTRA_ARGS
 if [[ ${CONFORMANCE} == "true" ]]; then
   FOCUS="\\[Conformance\\]"
+fi
+
+# If SET_VERSION is set, set the K8S_VERSION to the value of SET_VERSION
+if [[ ${SET_VERSION} == "true" ]]; then
+  EXTRA_ARGS="${EXTRA_ARGS} --conformance-image registry.k8s.io/conformance:${K8S_VERSION}"
 fi
 
 setup_kind

--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -109,7 +109,8 @@ func trimVersion(version string) (string, error) {
 
 	parsedVersion, err := semver.Parse(version)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error parsing conformance image tag: %v", err)
 	}
-	return parsedVersion.FinalizeVersion(), nil
+
+	return "v" + parsedVersion.FinalizeVersion(), nil
 }

--- a/pkg/common/args_test.go
+++ b/pkg/common/args_test.go
@@ -111,24 +111,52 @@ func TestTrimVersion(t *testing.T) {
 		name            string
 		version         string
 		expectedVersion string
+		expectErr       bool
 	}{
 		{
 			name:            "stable version",
 			version:         "v1.28.6",
-			expectedVersion: "1.28.6",
+			expectedVersion: "v1.28.6",
 		},
 		{
 			name:            "pre released version",
 			version:         "v1.28.6+0fb426",
-			expectedVersion: "1.28.6",
+			expectedVersion: "v1.28.6",
+		},
+		{
+			name:            "pre released version with build metadata",
+			version:         "v1.28.6+0fb426.20220304",
+			expectedVersion: "v1.28.6",
+		},
+		{
+			name:            "invalid version",
+			version:         "v1.28,0",
+			expectedVersion: "",
+			expectErr:       true,
+		},
+		{
+			name:            "short version",
+			version:         "v1.28",
+			expectedVersion: "",
+			expectErr:       true,
+		},
+		{
+			name:            "no v prefix",
+			version:         "1.28.6",
+			expectedVersion: "v1.28.6",
 		},
 	}
 
 	// Run the test cases
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			trimmedVersion, _ := trimVersion(tc.version)
+			trimmedVersion, err := trimVersion(tc.version)
 			assert.Equal(t, tc.expectedVersion, trimmedVersion)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
The trimmedVersion function was removing the v prefix from the version tag but not adding it back, causing conformance image pulls to fail. 

Additionally, this PR adds an extra flag to the test script so that by default we will test out the trimmed version functions by not explicitly setting them.