### PR TITLE
Improved logging for clusterrole and clusterbinding

### DIFF
--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -342,8 +342,9 @@ func Cleanup(clientset *kubernetes.Clientset) {
 		} else {
 			log.Fatal(err)
 		}
+	} else {
+		log.Printf("pod deleted %s\n", common.PodName)
 	}
-	log.Printf("pod deleted %s\n", common.PodName)
 
 	err = clientset.RbacV1().ClusterRoleBindings().Delete(ctx, common.ClusterRoleBindingName, metav1.DeleteOptions{})
 	if err != nil {
@@ -352,8 +353,9 @@ func Cleanup(clientset *kubernetes.Clientset) {
 		} else {
 			log.Fatal(err)
 		}
+	} else {
+		log.Printf("clusterrolebinding deleted %s\n", common.ClusterRoleBindingName)
 	}
-	log.Printf("clusterrolebinding deleted %s\n", common.ClusterRoleBindingName)
 
 	err = clientset.RbacV1().ClusterRoles().Delete(ctx, common.ClusterRoleName, metav1.DeleteOptions{})
 	if err != nil {
@@ -362,8 +364,9 @@ func Cleanup(clientset *kubernetes.Clientset) {
 		} else {
 			log.Fatal(err)
 		}
+	} else {
+		log.Printf("clusterrole deleted %s\n", common.ClusterRoleName)
 	}
-	log.Printf("clusterrole deleted %s\n", common.ClusterRoleName)
 
 	err = clientset.CoreV1().ServiceAccounts(namespace).Delete(ctx, common.ServiceAccountName, metav1.DeleteOptions{})
 	if err != nil {
@@ -372,8 +375,9 @@ func Cleanup(clientset *kubernetes.Clientset) {
 		} else {
 			log.Fatal(err)
 		}
+	} else {
+		log.Printf("serviceaccount deleted %s\n", common.ServiceAccountName)
 	}
-	log.Printf("serviceaccount deleted %s\n", common.ServiceAccountName)
 
 	err = clientset.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
 	if err != nil {
@@ -382,8 +386,9 @@ func Cleanup(clientset *kubernetes.Clientset) {
 		} else {
 			log.Fatal(err)
 		}
+	} else {
+		log.Printf("namespace deleted %s\n", namespace)
 	}
-	log.Printf("namespace deleted %s\n", namespace)
 }
 
 // DryRun returns an environment variable to tell the conformance test to run in dry run mode.

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -247,8 +247,9 @@ func RunE2E(clientset *kubernetes.Clientset) {
 		} else {
 			log.Fatal(err)
 		}
+	} else {
+		log.Printf("clusterrole created %s\n", clusterRole.Name)
 	}
-	log.Printf("clusterrole created %s\n", clusterRole.Name)
 
 	clusterRoleBinding, err := clientset.RbacV1().ClusterRoleBindings().Create(ctx, &conformanceClusterRoleBinding, metav1.CreateOptions{})
 	if err != nil {
@@ -257,8 +258,9 @@ func RunE2E(clientset *kubernetes.Clientset) {
 		} else {
 			log.Fatal(err)
 		}
+	} else {
+		log.Printf("clusterrolebinding created %s\n", clusterRoleBinding.Name)
 	}
-	log.Printf("clusterrolebinding created %s\n", clusterRoleBinding.Name)
 
 	if viper.GetString("test-repo-list") != "" {
 		RepoListData, err := os.ReadFile(viper.GetString("test-repo-list"))


### PR DESCRIPTION
fixes #161 

In previous when clusterrole and clusterrolebinding were present then both were logged exists one and created one both.

Previous action-
![Screenshot from 2024-02-19 23-14-09](https://github.com/kubernetes-sigs/hydrophone/assets/108119109/875af9b6-c816-4cc7-9ea6-46ab8dc536b0)

Current action-
![Screenshot from 2024-02-19 23-16-44](https://github.com/kubernetes-sigs/hydrophone/assets/108119109/91009c63-a765-4f26-a32f-040b9d360f99)