### PR TITLE
add context handling

### DIFF
--- a/pkg/client/check.go
+++ b/pkg/client/check.go
@@ -40,7 +40,7 @@ type streamLogs struct {
 }
 
 // PrintE2ELogs checks for Pod and start a go routine if new deployment added
-func (c *Client) PrintE2ELogs() {
+func (c *Client) PrintE2ELogs(ctx context.Context) {
 	informerFactory := informers.NewSharedInformerFactory(c.ClientSet, 10*time.Second)
 
 	podInformer := informerFactory.Core().V1().Pods()
@@ -60,7 +60,7 @@ func (c *Client) PrintE2ELogs() {
 				doneCh: make(chan bool),
 			}
 
-			go getPodLogs(c.ClientSet, stream)
+			go getPodLogs(ctx, c.ClientSet, stream)
 
 		loop:
 			for {
@@ -82,9 +82,9 @@ func (c *Client) PrintE2ELogs() {
 }
 
 // FetchExitCode waits for pod to be in terminated state and get the exit code
-func (c *Client) FetchExitCode() {
+func (c *Client) FetchExitCode(ctx context.Context) {
 	// Watching the pod's status
-	watchInterface, err := c.ClientSet.CoreV1().Pods(viper.GetString("namespace")).Watch(context.TODO(), metav1.ListOptions{
+	watchInterface, err := c.ClientSet.CoreV1().Pods(viper.GetString("namespace")).Watch(ctx, metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("metadata.name=%s", common.PodName),
 	})
 	if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -29,26 +29,27 @@ import (
 	"sigs.k8s.io/hydrophone/pkg/log"
 )
 
-var (
-	ctx = context.TODO()
-)
-
 // Client is a struct that holds the clientset and exit code
 type Client struct {
 	ClientSet *kubernetes.Clientset
 	ExitCode  int
 }
 
+// NewClient returns a new client
+func NewClient() *Client {
+	return &Client{}
+}
+
 // FetchFiles downloads the e2e.log and junit_01.xml files from the pod
 // and writes them to the output directory
-func (c *Client) FetchFiles(config *rest.Config, clientset *kubernetes.Clientset, outputDir string) {
+func (c *Client) FetchFiles(ctx context.Context, config *rest.Config, clientset *kubernetes.Clientset, outputDir string) {
 	log.Println("downloading e2e.log to ", filepath.Join(outputDir, "e2e.log"))
 	e2eLogFile, err := os.OpenFile(filepath.Join(outputDir, "e2e.log"), os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		log.Fatalf("unable to create e2e.log: %v\n", err)
 	}
 	defer e2eLogFile.Close()
-	err = downloadFile(config, clientset, viper.GetString("namespace"), common.PodName, common.OutputContainer, "/tmp/results/e2e.log", e2eLogFile)
+	err = downloadFile(ctx, config, clientset, viper.GetString("namespace"), common.PodName, common.OutputContainer, "/tmp/results/e2e.log", e2eLogFile)
 	if err != nil {
 		log.Fatalf("unable to download e2e.log: %v\n", err)
 	}
@@ -58,13 +59,8 @@ func (c *Client) FetchFiles(config *rest.Config, clientset *kubernetes.Clientset
 		log.Fatalf("unable to create junit_01.xml: %v\n", err)
 	}
 	defer junitXMLFile.Close()
-	err = downloadFile(config, clientset, viper.GetString("namespace"), common.PodName, common.OutputContainer, "/tmp/results/junit_01.xml", junitXMLFile)
+	err = downloadFile(ctx, config, clientset, viper.GetString("namespace"), common.PodName, common.OutputContainer, "/tmp/results/junit_01.xml", junitXMLFile)
 	if err != nil {
 		log.Fatalf("unable to download junit_01.xml: %v\n", err)
 	}
-}
-
-// NewClient returns a new client
-func NewClient() *Client {
-	return &Client{}
 }

--- a/pkg/client/download.go
+++ b/pkg/client/download.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-func downloadFile(config *rest.Config, clientset *kubernetes.Clientset,
+func downloadFile(ctx context.Context, config *rest.Config, clientset *kubernetes.Clientset,
 	namespace, podName, containerName, filePath string,
 	writer io.Writer) error {
 	// Create an exec request
@@ -59,7 +59,7 @@ func downloadFile(config *rest.Config, clientset *kubernetes.Clientset,
 
 	// Stream the file content from the container to the writer
 	return exec.StreamWithContext(
-		context.Background(),
+		ctx,
 		remotecommand.StreamOptions{
 			Stdout: writer,
 			Stderr: nil,

--- a/pkg/client/pod_log.go
+++ b/pkg/client/pod_log.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"bufio"
+	"context"
 
 	"github.com/spf13/viper"
 	v1 "k8s.io/api/core/v1"
@@ -27,7 +28,7 @@ import (
 )
 
 // List pod resource with the given namespace
-func getPodLogs(clientset *kubernetes.Clientset, stream streamLogs) {
+func getPodLogs(ctx context.Context, clientset *kubernetes.Clientset, stream streamLogs) {
 	podLogOpts := v1.PodLogOptions{
 		Container: common.ConformanceContainer,
 		Follow:    true,

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -36,10 +36,6 @@ import (
 	"sigs.k8s.io/hydrophone/pkg/log"
 )
 
-var (
-	ctx = context.Background()
-)
-
 // Init Initializes the kube config clientset
 func Init(kubeconfig string) (*rest.Config, *kubernetes.Clientset) {
 	config, err := rest.InClusterConfig()
@@ -77,7 +73,7 @@ func GetKubeConfig(kubeconfig string) string {
 }
 
 // RunE2E sets up the necessary resources and runs E2E conformance tests.
-func RunE2E(clientset *kubernetes.Clientset) {
+func RunE2E(ctx context.Context, clientset *kubernetes.Clientset) {
 	conformanceNS := v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: viper.GetString("namespace"),
@@ -331,7 +327,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 }
 
 // Cleanup removes all resources created during E2E tests.
-func Cleanup(clientset *kubernetes.Clientset) {
+func Cleanup(ctx context.Context, clientset *kubernetes.Clientset) {
 	namespace := viper.GetString("namespace")
 	log.Printf("using namespace: %v", namespace)
 

--- a/pkg/service/list_images.go
+++ b/pkg/service/list_images.go
@@ -36,7 +36,7 @@ import (
 
 // PrintListImages creates and runs a conformance image with the --list-images flag
 // This will print a list of all the images used by the conformance image.
-func PrintListImages(clientSet *kubernetes.Clientset) {
+func PrintListImages(ctx context.Context, clientSet *kubernetes.Clientset) {
 	// Create a pod object definition
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -62,7 +62,7 @@ func PrintListImages(clientSet *kubernetes.Clientset) {
 	}
 
 	// Create the pod in the cluster
-	pod, err := clientSet.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+	pod, err := clientSet.CoreV1().Pods("default").Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		panic(fmt.Errorf("failed to create pod: %w", err))
 	}
@@ -70,7 +70,7 @@ func PrintListImages(clientSet *kubernetes.Clientset) {
 	log.Printf("Pod created successfully")
 
 	// Watch for pod events
-	watcher, err := clientSet.CoreV1().Pods("default").Watch(context.TODO(), metav1.ListOptions{
+	watcher, err := clientSet.CoreV1().Pods("default").Watch(ctx, metav1.ListOptions{
 		FieldSelector: "metadata.name=" + pod.Name,
 	})
 	if err != nil {
@@ -100,7 +100,7 @@ func PrintListImages(clientSet *kubernetes.Clientset) {
 
 				// Fetch the logs
 				req := clientSet.CoreV1().Pods("default").GetLogs(pod.Name, &corev1.PodLogOptions{})
-				podLogs, err := req.Stream(context.TODO())
+				podLogs, err := req.Stream(ctx)
 				if err != nil {
 					log.Fatal("failed to fetch pod logs: %w", err)
 				}


### PR DESCRIPTION
This removes the TODO/Background contexts sprinkled throughout pkg/ and replaces them with a common context.Context parameter. The root command then uses the command's context for all the functions it calls.