### PR TITLE
fix help text for --config flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,7 +98,7 @@ func init() {
 
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.Flags().StringVar(&cfgFile, "config", "", fmt.Sprintf("Default config file (%s/hydrophone/hydrophone.yaml)", xdg.ConfigHome))
+	rootCmd.Flags().StringVar(&cfgFile, "config", "", fmt.Sprintf("config file (defaults to %s/hydrophone.yaml).", xdg.ConfigHome))
 	rootCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "path to the kubeconfig file.")
 
 	rootCmd.Flags().IntVar(&parallel, "parallel", 1, "number of parallel threads in test framework.")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -52,7 +52,7 @@ func (c *Client) FetchFiles(config *rest.Config, clientset *kubernetes.Clientset
 	if err != nil {
 		log.Fatalf("unable to download e2e.log: %v\n", err)
 	}
-	log.Println("downloading junit_01.xml to", filepath.Join(outputDir, "junit_01.xml"))
+	log.Println("downloading junit_01.xml to ", filepath.Join(outputDir, "junit_01.xml"))
 	junitXMLFile, err := os.OpenFile(filepath.Join(outputDir, "junit_01.xml"), os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		log.Fatalf("unable to create junit_01.xml: %v\n", err)


### PR DESCRIPTION
Viper's computed file path `~/.config/hydrophone.yaml` on my system, and after running hydrophone, I do not have a `~/.config/hydrophone/` directory, so I presume the default values was simply a typo. The comment in line 155 agrees with me.