### PR TITLE
use golangci-lint as linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,56 @@
+run:
+  timeout: 15m
+
+# all available settings of specific linters
+linters-settings:
+  gocritic:
+    enabled-tags:
+      - performance
+      - diagnostic
+      - style
+      - experimental
+      - opinionated
+    disabled-checks:
+      - hugeParam
+      - rangeValCopy
+      - unnamedResult
+  gofmt:
+    simplify: true
+  goimports:
+    # put imports beginning with prefix after 3rd-party packages;
+    # it's a comma-separated list of prefixes
+    local-prefixes: sigs.k8s.io/hydrophone
+  errcheck:
+    check-type-assertions: false
+    check-blank: false
+  staticcheck:
+    checks:
+    - all
+
+# options for analysis running
+issues:
+  exclude-dirs:
+    - hack
+    - docs
+
+  # include test files
+  tests: true
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - gocritic
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - prealloc
+    - revive
+    - staticcheck
+    - stylecheck
+    - unconvert
+    - unparam
+    - unused

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:errcheck // TODO(embik): temporary put in place to ensure PRs do not conflict
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,13 +20,14 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/adrg/xdg"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"sigs.k8s.io/hydrophone/pkg/client"
 	"sigs.k8s.io/hydrophone/pkg/common"
 	"sigs.k8s.io/hydrophone/pkg/log"
 	"sigs.k8s.io/hydrophone/pkg/service"
+
+	"github.com/adrg/xdg"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -52,7 +53,7 @@ var rootCmd = &cobra.Command{
 	Use:   "hydrophone",
 	Short: "Hydrophone is a lightweight runner for Kubernetes tests.",
 	Long:  `Hydrophone is a lightweight runner for Kubernetes tests.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx := cmd.Context()
 
 		client := client.NewClient()

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -22,12 +22,12 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 cd "${KUBE_ROOT}"
 
-LINT=${LINT:-golint}
+LINT=${LINT:-golangci-lint}
 
 if [[ -z "$(command -v ${LINT})" ]]; then
   echo "${LINT} is missing. Installing it now."
-  go install golang.org/x/lint/golint@latest >/dev/null 2>&1
-  LINT=$(go env GOPATH)/bin/golint
+  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2 >/dev/null 2>&1
+  LINT=$(go env GOPATH)/bin/golangci-lint
 fi
 
 ${LINT} run

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -55,7 +55,7 @@ func (c *Client) FetchFiles(ctx context.Context, config *rest.Config, clientset 
 }
 
 // FetchFiles downloads a single file from the output container to the local machine.
-func (c *Client) fetchFile(ctx context.Context, config *rest.Config, clientset *kubernetes.Clientset, outputDir string, filename string) error {
+func (c *Client) fetchFile(ctx context.Context, config *rest.Config, clientset *kubernetes.Clientset, outputDir, filename string) error {
 	dest := filepath.Join(outputDir, filename)
 	log.Printf("Downloading %s to %s...", filename, dest)
 

--- a/pkg/common/args.go
+++ b/pkg/common/args.go
@@ -92,7 +92,7 @@ func ValidateConformanceArgs() error {
 		viper.Get("parallel"), viper.Get("verbosity"))
 
 	outputDir := viper.GetString("output-dir")
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return fmt.Errorf("error creating output directory [%s]: %w", outputDir, err)
 	}
 	return nil

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -59,7 +59,7 @@ func GetKubeConfig(kubeconfig string) string {
 	homeDir := os.Getenv("HOME")
 	if kubeconfig == "" {
 		kubeconfig = filepath.Join(homeDir, ".kube", "config")
-		if envvar := os.Getenv("KUBECONFIG"); len(envvar) > 0 {
+		if envvar := os.Getenv("KUBECONFIG"); envvar != "" {
 			kubeconfig = envvar
 		}
 	}
@@ -222,6 +222,7 @@ func RunE2E(ctx context.Context, clientset *kubernetes.Clientset) error {
 	ns, err := clientset.CoreV1().Namespaces().Create(ctx, &conformanceNS, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
+			//nolint:stylecheck // error message references a Kubernetes resource type.
 			err = fmt.Errorf("Namespace %s already exist, please run --cleanup first", conformanceNS.Name)
 		}
 
@@ -232,6 +233,7 @@ func RunE2E(ctx context.Context, clientset *kubernetes.Clientset) error {
 	sa, err := clientset.CoreV1().ServiceAccounts(ns.Name).Create(ctx, &conformanceSA, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
+			//nolint:stylecheck // error message references a Kubernetes resource type.
 			err = fmt.Errorf("ServiceAccount %s already exist, please run --cleanup first", conformanceSA.Name)
 		}
 
@@ -242,6 +244,7 @@ func RunE2E(ctx context.Context, clientset *kubernetes.Clientset) error {
 	clusterRole, err := clientset.RbacV1().ClusterRoles().Create(ctx, &conformanceClusterRole, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
+			//nolint:stylecheck // error message references a Kubernetes resource type.
 			err = fmt.Errorf("ClusterRole %s already exist, please run --cleanup first", conformanceClusterRole.Name)
 		}
 
@@ -252,6 +255,7 @@ func RunE2E(ctx context.Context, clientset *kubernetes.Clientset) error {
 	clusterRoleBinding, err := clientset.RbacV1().ClusterRoleBindings().Create(ctx, &conformanceClusterRoleBinding, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
+			//nolint:stylecheck // error message references a Kubernetes resource type.
 			err = fmt.Errorf("ClusterRoleBinding %s already exist, please run --cleanup first", conformanceClusterRoleBinding.Name)
 		}
 
@@ -302,6 +306,7 @@ func RunE2E(ctx context.Context, clientset *kubernetes.Clientset) error {
 		cm, err := clientset.CoreV1().ConfigMaps(ns.Name).Create(ctx, configMap, metav1.CreateOptions{})
 		if err != nil {
 			if errors.IsAlreadyExists(err) {
+				//nolint:stylecheck // error message references a Kubernetes resource type.
 				err = fmt.Errorf("ConfigMap %s already exist, please run --cleanup first", configMap.Name)
 			}
 
@@ -320,6 +325,7 @@ func RunE2E(ctx context.Context, clientset *kubernetes.Clientset) error {
 	pod, err := clientset.CoreV1().Pods(ns.Name).Create(ctx, &conformancePod, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
+			//nolint:stylecheck // error message references a Kubernetes resource type.
 			err = fmt.Errorf("Pod %s already exist, please run --cleanup first", conformancePod.Name)
 		}
 

--- a/pkg/service/init_test.go
+++ b/pkg/service/init_test.go
@@ -42,7 +42,7 @@ func TestGetKubeConfig(t *testing.T) {
 
 	// Test case 3: kubeconfig starts with "~"
 	kubeconfig = "~/custom/kubeconfig"
-	expected = filepath.Join(os.Getenv("HOME"), "custom/kubeconfig")
+	expected = filepath.Join(os.Getenv("HOME"), "custom", "kubeconfig")
 	actual = GetKubeConfig(kubeconfig)
 	if actual != expected {
 		t.Errorf("Expected %s, but got %s", expected, actual)

--- a/pkg/service/list_images.go
+++ b/pkg/service/list_images.go
@@ -25,9 +25,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/viper"
 	"sigs.k8s.io/hydrophone/pkg/common"
 	"sigs.k8s.io/hydrophone/pkg/log"
+
+	"github.com/spf13/viper"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/service/list_images.go
+++ b/pkg/service/list_images.go
@@ -95,39 +95,43 @@ func PrintListImages(ctx context.Context, clientSet *kubernetes.Clientset) error
 
 			// Check if the pod is in a terminal state
 			if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
-				// Trigger desired action (e.g., fetching and printing logs)
-				log.Printf("Pod completed: %s", pod.Status.Phase)
-
-				// Fetch the logs
-				req := clientSet.CoreV1().Pods("default").GetLogs(pod.Name, &corev1.PodLogOptions{})
-				podLogs, err := req.Stream(ctx)
-				if err != nil {
-					return fmt.Errorf("failed to fetch Pod logs: %w", err)
-				}
-				defer podLogs.Close()
-
-				// Read and print the logs
-				buf := new(bytes.Buffer)
-				_, err = io.Copy(buf, podLogs)
-				if err != nil {
-					return fmt.Errorf("failed to read Pod logs: %w", err)
-				}
-
-				lines := strings.Split(buf.String(), "\n")
-				sort.Strings(lines)
-				for _, line := range lines {
-					fmt.Println(line)
-				}
-
-				err = clientSet.CoreV1().Pods("default").Delete(ctx, pod.Name, metav1.DeleteOptions{})
-				if err != nil {
-					return fmt.Errorf("failed to delete Pod: %w", err)
-				}
-				return nil
+				return handlePod(ctx, clientSet, pod)
 			}
-
 		case <-time.After(2 * time.Second):
 			// Check status every 2 seconds
 		}
 	}
+}
+
+func handlePod(ctx context.Context, clientSet *kubernetes.Clientset, pod *corev1.Pod) error {
+	// Trigger desired action (e.g., fetching and printing logs)
+	log.Printf("Pod completed: %s", pod.Status.Phase)
+
+	// Fetch the logs
+	req := clientSet.CoreV1().Pods("default").GetLogs(pod.Name, &corev1.PodLogOptions{})
+	podLogs, err := req.Stream(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch Pod logs: %w", err)
+	}
+	defer podLogs.Close()
+
+	// Read and print the logs
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, podLogs)
+	if err != nil {
+		return fmt.Errorf("failed to read Pod logs: %w", err)
+	}
+
+	lines := strings.Split(buf.String(), "\n")
+	sort.Strings(lines)
+	for _, line := range lines {
+		fmt.Println(line)
+	}
+
+	err = clientSet.CoreV1().Pods("default").Delete(ctx, pod.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete Pod: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
`golangci-lint` is a pretty good linter for Go projects. This updates the existing `hack/verify-golint.sh` script to install that instead of `golang.org/x/lint/golint`.

The `.golangci.yml` configuration file is adapted from https://github.com/kubernetes-sigs/krew/blob/master/.golangci.yml. Felt like a pretty good starting point, we can gradually enable linters that seem useful.

This PR is currently a WIP because the new linter uncovers a couple of problems, but some of them are already addressed in #165. I'll wait for that PR to move forward (in any direction) before fixing linter-discovered problems in this PR to minimise conflict with the existing PR.