### PR TITLE
fail boilerplate check if non-compliant files are detected

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -203,12 +203,17 @@ def main():
     regexs = get_regexs()
     refs = get_refs()
     filenames = get_files(refs.keys())
+    failures = 0
 
     for filename in filenames:
         if not file_passes(filename, refs, regexs):
+            failures += 1
             print(filename, file=sys.stdout)
 
-    return 0
+    if failures == 0:
+        return 0
+
+    return 1
 
 
 if __name__ == "__main__":

--- a/pkg/common/spinner.go
+++ b/pkg/common/spinner.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package common
 
 import (


### PR DESCRIPTION
The current `boilerplate.py` script doesn't return an exit code to signal that the check failed, so the `make verify` command doesn't fail. It prints that files are missing boilerplate, but that is hidden in the prow job logs. The `verify` prow job succeeds though.

This PR updates the Python script to return exit code feedback so that `make verify` fails. I discovered a non-compliant file, `pkg/common/spinner.go`, which was contributed in #148 by @Bharadwajshivam28. I'm not 100% sure if this PR needs sign off by them (I assume the contribution is made under Apache license anyway).