### PR TITLE
prevent broken junit report files

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -59,7 +59,7 @@ func (c *Client) fetchFile(ctx context.Context, config *rest.Config, clientset *
 	dest := filepath.Join(outputDir, filename)
 	log.Printf("Downloading %s to %s...", filename, dest)
 
-	localFile, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE, 0600)
+	localFile, err := os.Create(dest)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This code was missing O_TRUNC.

Without it, my first hydrophone run randomly had issues and was dumping a 142MB junit_01.xml, containing lots of pod logs. I then re-ran hydrophone on another cluster where the tests succeeded, but I still _seemingly_ got a 142MB file.

In reality, hydrophone was fetching a 2.5MB file and was only updating/replacing the first 2.5MB of my junit_01.xml file, instead of overwriting it completely.

Adding O_TRUNC would make this more or less equivalent to OpenFile(), except that Create() sets file permissions to 0666 instead of our 0600, which I think is perfectly acceptable. The junit/e2e logs are not secret data that should be kept from other users on the system.