### PR TITLE
hide spinner on -v <= 2, show test logs in realtime with -v >= 6

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,17 +82,27 @@ var rootCmd = &cobra.Command{
 				log.Fatalf("Invalid arguments: %v.", err)
 			}
 
-			if err := service.RunE2E(ctx, client.ClientSet); err != nil {
+			verboseGinkgo := verbosity >= 6
+			showSpinner := !verboseGinkgo && verbosity > 2
+
+			if err := service.RunE2E(ctx, client.ClientSet, verboseGinkgo); err != nil {
 				log.Fatalf("Failed to run tests: %v.", err)
 			}
 
-			spinner := common.NewSpinner(os.Stdout)
-			spinner.Start()
+			var spinner *common.Spinner
+			if showSpinner {
+				spinner = common.NewSpinner(os.Stdout)
+				spinner.Start()
+			}
+
 			// PrintE2ELogs is a long running method
 			if err := client.PrintE2ELogs(ctx); err != nil {
 				log.Fatalf("Failed to get test logs: %v.", err)
 			}
-			spinner.Stop()
+
+			if showSpinner {
+				spinner.Stop()
+			}
 
 			if err := client.FetchFiles(ctx, config, clientSet, viper.GetString("output-dir")); err != nil {
 				log.Fatalf("Failed to download results: %v.", err)
@@ -103,13 +113,13 @@ var rootCmd = &cobra.Command{
 			if err := service.Cleanup(ctx, client.ClientSet); err != nil {
 				log.Fatalf("Failed to cleanup: %v.", err)
 			}
-		}
 
-		if client.ExitCode == 0 {
-			log.Println("Tests completed successfully.")
-		} else {
-			log.Printf("Tests failed (code %d).", client.ExitCode)
-			os.Exit(client.ExitCode)
+			if client.ExitCode == 0 {
+				log.Println("Tests completed successfully.")
+			} else {
+				log.Printf("Tests failed (code %d).", client.ExitCode)
+				os.Exit(client.ExitCode)
+			}
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -194,7 +194,7 @@ func initConfig() {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
 	} else {
-		// the config will belocated under `~/.config/hydrophone.yaml` on linux
+		// the config will be located under `~/.config/hydrophone.yaml` on linux
 		configDir := xdg.ConfigHome
 		viper.AddConfigPath(configDir)
 		viper.SetConfigType("yaml")

--- a/docs/air-gapped.md
+++ b/docs/air-gapped.md
@@ -22,7 +22,7 @@ To print the list of images, run:
 hydrophone --list-images
 ```
 
-This list contains images required to run the tests inside the conformance image. However, it does not include the conformance image itself or the busybox image that hydrophone uses to pull test results. The images identified will need to be pulled from the public registry and transfered to the internal registry.
+This list contains images required to run the tests inside the conformance image. However, it does not include the conformance image itself or the busybox image that hydrophone uses to pull test results. The images identified will need to be pulled from the public registry and transferred to the internal registry.
 
 ## Preparing the Internal Registry
 

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -49,6 +49,7 @@ function run_test {
     --focus "${FOCUS}" \
     --skip "${SKIP}" \
     --namespace "${NAMESPACE}" \
+    --verbosity 2 \
     $EXTRA_ARGS | tee /tmp/test.log
 
   # Check if $CHECK_DURATION is set to true

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -60,7 +60,7 @@ do
     echo "Skipping $t"
     continue
   fi
-  echo "Runnint: $t"
+  echo "Running: $t"
   if $SILENT ; then
     echo -e "Verifying $t"
     if bash "$t" &> /dev/null; then

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -77,7 +77,7 @@ func namespacedName(basename string) string {
 }
 
 // RunE2E sets up the necessary resources and runs E2E conformance tests.
-func RunE2E(ctx context.Context, clientset *kubernetes.Clientset) error {
+func RunE2E(ctx context.Context, clientset *kubernetes.Clientset, verboseGinkgo bool) error {
 	namespace := viper.GetString("namespace")
 
 	conformanceNS := v1.Namespace{
@@ -222,6 +222,13 @@ func RunE2E(ctx context.Context, clientset *kubernetes.Clientset) error {
 		conformancePod.Spec.Containers[0].Env = append(conformancePod.Spec.Containers[0].Env, v1.EnvVar{
 			Name:  "E2E_DRYRUN",
 			Value: "true",
+		})
+	}
+
+	if verboseGinkgo {
+		conformancePod.Spec.Containers[0].Env = append(conformancePod.Spec.Containers[0].Env, v1.EnvVar{
+			Name:  "E2E_EXTRA_GINKGO_ARGS",
+			Value: "-v",
 		})
 	}
 


### PR DESCRIPTION
This PR makes more use of the `--verbosity` flag.

* The default value, 4, is kept with the same behaviour: Show a spinner.
* If v <= 2, then no spinner is shown, useful for e2e jobs.
* If v >= 6, then the spinner is replaced with the live test output.

This would fix #168.