### PR TITLE
Exit process if conformance pod ImagePullBackOff.

### DIFF
--- a/pkg/client/check.go
+++ b/pkg/client/check.go
@@ -80,6 +80,7 @@ func (c *Client) PrintE2ELogs(ctx context.Context) error {
 			}
 			break
 		}
+		common.ExitWhenImagePullBackOff(pod)
 	}
 
 	return nil

--- a/pkg/common/pod.go
+++ b/pkg/common/pod.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"errors"
+
+	"sigs.k8s.io/hydrophone/pkg/log"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// Exit process if conformance pod happen ImagePullBackOff.
+func ExitWhenImagePullBackOff(pod *v1.Pod) {
+	if pod.Status.Phase != v1.PodPending {
+		return
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Waiting != nil && cs.State.Waiting.Reason == "ImagePullBackOff" {
+			log.Fatal(errors.New(cs.State.Waiting.Message))
+		}
+	}
+}

--- a/pkg/service/list_images.go
+++ b/pkg/service/list_images.go
@@ -97,6 +97,7 @@ func PrintListImages(ctx context.Context, clientSet *kubernetes.Clientset) error
 			if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
 				return handlePod(ctx, clientSet, pod)
 			}
+			common.ExitWhenImagePullBackOff(pod)
 		case <-time.After(2 * time.Second):
 			// Check status every 2 seconds
 		}


### PR DESCRIPTION
I'm tring the hydrophone with my kind kubernetes `ghcr.io/liangyuanpeng/kindest/testnode:v1.31.0-alpha.0-24-g9791f0d1f39` and  since have not image `registry.k8s.io/conformance:v1.31.0`, hydrophone will never not exit until the github action 6-hour timeout limit is reached. ( I'm running it on the gthub action. )

So this PR is working for print the error message of ImagePullBackOff and let hydrophone  exit if conformance pod pending with ImagePullBackOff.

here is the logs after this PR.

```shell
$:~/lan/hydrophone$ bin/hydrophone --list-images 
23:17:14 INF API endpoint: https://127.0.0.1:38453/
23:17:14 INF Server version: version.Info{Major:"1", Minor:"31+", GitVersion:"v1.31.0-alpha.0.24+9791f0d1f39f3f", GitCommit:"9791f0d1f39f3f1e0796add7833c1059325d5098", GitTreeState:"clean", BuildDate:"2024-04-07T13:06:59Z", GoVersion:"go1.22.2", Compiler:"gc", Platform:"linux/amd64"}
23:17:14 INF Using namespace: conformance
23:17:14 INF Using conformance image: registry.k8s.io/conformance:v1.31.0
23:17:14 INF Using busybox image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
23:17:14 INF Created Pod list-images-2bctp.
23:17:14 INF Waiting for Pod to complete...
23:17:28 ERR Back-off pulling image "registry.k8s.io/conformance:v1.31.0"

$:~/lan/hydrophone$ bin/hydrophone
23:17:56 INF API endpoint: https://127.0.0.1:38453/
23:17:56 INF Server version: version.Info{Major:"1", Minor:"31+", GitVersion:"v1.31.0-alpha.0.24+9791f0d1f39f3f", GitCommit:"9791f0d1f39f3f1e0796add7833c1059325d5098", GitTreeState:"clean", BuildDate:"2024-04-07T13:06:59Z", GoVersion:"go1.22.2", Compiler:"gc", Platform:"linux/amd64"}
23:17:56 INF Using namespace: conformance
23:17:56 INF Using conformance image: registry.k8s.io/conformance:v1.31.0
23:17:56 INF Using busybox image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
23:17:56 INF Test framework will start 1 thread(s) and use verbosity level 4.
23:17:56 INF Created Namespace conformance.
23:17:56 INF Created ServiceAccount conformance-serviceaccount.
23:17:56 INF Created Clusterrole conformance-serviceaccount:conformance.
23:17:56 INF Created ClusterRoleBinding conformance-serviceaccount-role:conformance.
23:17:56 INF Created Pod e2e-conformance-test.
⠈⡱15:18:00 ERR Back-off pulling image "registry.k8s.io/conformance:v1.31.0"
```
 
/assign @dims @rjsadow