### PR TITLE
update kind in e2e tests to 0.22

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -87,8 +87,8 @@ function evaluate_test_num {
 }
 
 # Default versions k8s and kind
-K8S_VERSION=${K8S_VERSION:-v1.29.0}
-KIND_VERSION=${KIND_VERSION:-v0.20.0}
+K8S_VERSION=${K8S_VERSION:-v1.29.2}
+KIND_VERSION=${KIND_VERSION:-v0.22.0}
 
 # Maximum time (in seconds) for a dry run test
 DRYRUN_THRESHOLD=${DRYRUN_DURATION:-5}


### PR DESCRIPTION
This PR bumps kind to the latest stable version and sets the kube version to kind's default node version.

I saw that https://github.com/kubernetes-sigs/hydrophone/actions/workflows/update-deps.yml is broken, @embik wanted to maybe take a look at it. That job can then bump us to 1.30, as intended.