### PR TITLE
Update update-deps workflow to Go 1.22

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21.5'
+          go-version: '1.22.2'
 
       - name: Update Dependencies
         id: update_deps


### PR DESCRIPTION
It seems that the `update-deps` workflow is broken since #145, since that bumped the Go version in `go.mod` to 1.22. This should fix the workflow to get automated dependency updates again.