### PR TITLE
add --continue flag to resume/reconnect to a running conformance test

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,6 +38,7 @@ Flags:
   -c, --config string               path to an optional base configuration file.
       --conformance                 run conformance tests.
       --conformance-image string    specify a conformance container image of your choice.
+      --continue                    connect to an already running conformance test pod.
       --dry-run                     run in dry run mode.
       --extra-args strings          Additional parameters to be provided to the conformance container. These parameters should be specified as key-value pairs, separated by commas. Each parameter should start with -- (e.g., --clean-start=true,--allowed-not-ready-nodes=2)
       --extra-ginkgo-args strings   Additional parameters to be provided to Ginkgo runner. This flag has the same format as --extra-args.


### PR DESCRIPTION
If the cluster is too weak or the network too flaky, it can happen that hydrophone loses connection to the test Pod. This currently means the test is basically dead and you have to start over.

This PR adds a new `--continue` flag which will simply skil the Pod creation and then connect to the existing Pod, effectively resuming the test and allowing the user to recover.