### PR TITLE
Set the default logger only in the CLI.

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ import (
 )
 
 func main() {
+	log.SetDefaultLogger()
+
 	if err := cmd.New().Execute(); err != nil {
 		log.Fatalf("Error: %v.", err)
 	}

--- a/pkg/log/logs.go
+++ b/pkg/log/logs.go
@@ -26,8 +26,8 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
-func init() {
-	// set global logger with custom options
+// SetDefaultLogger set global logger with custom options.
+func SetDefaultLogger() {
 	slog.SetDefault(slog.New(
 		tint.NewHandler(os.Stderr, &tint.Options{
 			Level:      slog.LevelDebug,


### PR DESCRIPTION
If hydrophone is used as a library, setting a default logger in `init()` function might be not the best option.