### PR TITLE
Wait for the namespace to be deleted.

### DIFF
--- a/pkg/conformance/cleanup.go
+++ b/pkg/conformance/cleanup.go
@@ -18,15 +18,21 @@ package conformance
 
 import (
 	"context"
+	"fmt"
 
 	"sigs.k8s.io/hydrophone/pkg/log"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 // Cleanup removes all resources created during E2E tests.
 func (r *TestRunner) Cleanup(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	name := r.namespacedName(ClusterRoleBindingName)
 	err := r.clientset.RbacV1().ClusterRoleBindings().Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
@@ -47,15 +53,42 @@ func (r *TestRunner) Cleanup(ctx context.Context) error {
 		log.Printf("Deleted ClusterRole %s.", name)
 	}
 
+	// start a watcher before deleting the namespace
+	watcher, err := r.clientset.CoreV1().Namespaces().Watch(ctx, metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", r.config.Namespace).String(),
+	})
+	if err != nil {
+		return err
+	}
+
+	defer watcher.Stop()
+
 	name = r.config.Namespace
 	err = r.clientset.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
-	} else {
-		log.Printf("Deleted Namespace %s.", name)
+
+		return nil
 	}
 
-	return nil
+	log.Printf("Waiting for Namespace %s to be deleted.", name)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event := <-watcher.ResultChan():
+			if event.Type == watch.Error {
+				return fmt.Errorf("error watching waiting for namespace deletion")
+			}
+
+			if event.Type == watch.Deleted {
+				log.Printf("Deleted Namespace %s.", name)
+
+				return nil
+			}
+		}
+	}
 }


### PR DESCRIPTION
Without this fix, an attempt to run the test two times might fail, as the namespace hasn't been deleted yet.