### PR TITLE
Add weekly vulnerability scans

### DIFF
--- a/.github/workflows/weekly-trivy-scan.yml
+++ b/.github/workflows/weekly-trivy-scan.yml
@@ -1,0 +1,33 @@
+name: Weekly Trivy Scan 
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Run at midnight every Sunday
+  workflow_dispatch:     # Allow manual triggering
+
+jobs:
+  trivy-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          
+      - name: Get commit SHA
+        id: vars
+        run: echo "image_tag=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build Docker image (no cache)
+        run: |
+          docker build --no-cache -t hydrophone:${{ steps.vars.outputs.image_tag }} .
+
+      - name: Run vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: hydrophone:${{ steps.vars.outputs.image_tag }}
+          format: 'table'
+          exit-code: '1'
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH,MEDIUM'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
**What this PR does / why we need it:** Adds a new GitHub workflow for weekly vulnerability scanning of Hydrophone image. This helps us proactively identify security vulnerabilities before they become critical issues.

Test run: https://github.com/farazkhawaja/hydrophone/actions/runs/14956212113