### PR TITLE
set time to UTC

### DIFF
--- a/pkg/log/logs.go
+++ b/pkg/log/logs.go
@@ -33,6 +33,12 @@ func SetDefaultLogger() {
 			Level:      slog.LevelDebug,
 			TimeFormat: time.TimeOnly,
 			NoColor:    !isatty.IsTerminal(os.Stderr.Fd()),
+			ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+				if a.Key == slog.TimeKey {
+					return slog.Time(a.Key, a.Value.Time().UTC())
+				}
+				return a
+			},
 		}),
 	))
 }


### PR DESCRIPTION
Addresses the issue: https://github.com/kubernetes-sigs/hydrophone/issues/117

hydrophone logger now set to log time in UTC which aligns with the time logged by gingko run.

![image](https://github.com/user-attachments/assets/311afe1d-2d8f-465d-bae5-08c61c100b19)
