### PR TITLE
update golangci-lint to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,56 +1,60 @@
+version: "2"
 run:
   timeout: 15m
-
-# all available settings of specific linters
-linters-settings:
-  gocritic:
-    enabled-tags:
-      - performance
-      - diagnostic
-      - style
-      - experimental
-      - opinionated
-    disabled-checks:
-      - hugeParam
-      - rangeValCopy
-      - unnamedResult
-  gofmt:
-    simplify: true
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: sigs.k8s.io/hydrophone
-  errcheck:
-    check-type-assertions: false
-    check-blank: false
-  staticcheck:
-    checks:
-    - all
-
-# options for analysis running
-issues:
-  exclude-dirs:
-    - hack
-    - docs
-
-  # include test files
-  tests: true
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
     - gocritic
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - prealloc
     - revive
     - staticcheck
-    - stylecheck
     - unconvert
     - unparam
     - unused
+  settings:
+    errcheck:
+      check-type-assertions: false
+      check-blank: false
+    gocritic:
+      disabled-checks:
+        - hugeParam
+        - rangeValCopy
+        - unnamedResult
+      enabled-tags:
+        - performance
+        - diagnostic
+        - style
+        - experimental
+        - opinionated
+    staticcheck:
+      checks:
+        - all
+  exclusions:
+    generated: strict 
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - hack
+      - docs
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+        - sigs.k8s.io/hydrophone
+  exclusions:
+    generated: strict
+    paths:
+      - hack
+      - docs

--- a/pkg/conformance/deploy.go
+++ b/pkg/conformance/deploy.go
@@ -350,7 +350,7 @@ func (r *TestRunner) Deploy(ctx context.Context, focus, skipPreflight string, ve
 				log.Printf("using existing Pod: %s/%s", r.config.Namespace, "e2e-conformance-test")
 			} else {
 				//nolint:stylecheck // error message references a Kubernetes resource type.
-				return fmt.Errorf("Pod %s already exist, please run --cleanup first", conformanceClusterRoleBinding.Name)
+				return fmt.Errorf("pod %s already exist, please run --cleanup first", conformanceClusterRoleBinding.Name)
 			}
 		} else {
 			return fmt.Errorf("failed to create Pod: %w", err)


### PR DESCRIPTION
This updates the golangci-lint configuration to use v2 and addresses one small lint that came from using the existing, but migrated configuration.

resolves #245 