### PR TITLE
bumps update-deps go to match go.mod

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22.2'
+          go-version: '1.24.2'
 
       - name: Update Dependencies
         id: update_deps


### PR DESCRIPTION
This bumps the go configured for the `update-deps` workflow to match the one configured in `go.mod`

resolves #244 