### PR TITLE
Add progress indicator to output logs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -126,7 +126,7 @@ func action(ctx context.Context, config *types.Configuration) error {
 
 	// prepare test runner and the client to monitor it
 	testRunner := conformance.NewTestRunner(*config, clientset)
-	testClient := client.NewClient(restConfig, clientset, config.Namespace)
+	testClient := client.NewClient(restConfig, clientset, config.Namespace, config)
 
 	switch {
 	case runCleanup:

--- a/pkg/conformance/client/client.go
+++ b/pkg/conformance/client/client.go
@@ -17,22 +17,26 @@ limitations under the License.
 package client
 
 import (
+	"sigs.k8s.io/hydrophone/pkg/types"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
 // Client is used to retrieve conformance test logs, results and status information.
 type Client struct {
-	config    *rest.Config
-	clientset *kubernetes.Clientset
-	namespace string
+	config         *rest.Config
+	clientset      *kubernetes.Clientset
+	namespace      string
+	configuration  *types.Configuration
 }
 
 // NewClient creates a client for interacting with the conformance test pod
-func NewClient(config *rest.Config, clientset *kubernetes.Clientset, namespace string) *Client {
+func NewClient(config *rest.Config, clientset *kubernetes.Clientset, namespace string, configuration *types.Configuration) *Client {
 	return &Client{
-		config:    config,
-		clientset: clientset,
-		namespace: namespace,
+		config:        config,
+		clientset:     clientset,
+		namespace:     namespace,
+		configuration: configuration,
 	}
 }

--- a/pkg/conformance/client/logs.go
+++ b/pkg/conformance/client/logs.go
@@ -109,8 +109,10 @@ func (c *Client) streamPodLogs(ctx context.Context, stream streamLogs) {
 	}
 	defer podLogs.Close()
 
-	// Start a goroutine to watch test status and provide periodic updates
-	go c.watchStatus(ctx, stream)
+	// Start a goroutine to watch test status and provide periodic updates if disable-progress-status flag not set
+	if !c.configuration.DisableProgressStatus {
+		go c.watchStatus(ctx, stream)
+	}
 
 	reader := bufio.NewScanner(podLogs)
 
@@ -225,7 +227,7 @@ func (c *Client) watchStatus(ctx context.Context, stream streamLogs) {
 			}
 
 			// Wait before checking again
-			time.Sleep(30 * time.Second)
+			time.Sleep(c.configuration.ProgressStatusInterval)
 		}
 	}
 }

--- a/pkg/conformance/client/logs.go
+++ b/pkg/conformance/client/logs.go
@@ -18,9 +18,12 @@ package client
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"sigs.k8s.io/hydrophone/pkg/conformance"
@@ -28,7 +31,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/utils/ptr"
 )
 
@@ -100,8 +105,12 @@ func (c *Client) streamPodLogs(ctx context.Context, stream streamLogs) {
 	podLogs, err := req.Stream(ctx)
 	if err != nil {
 		stream.errCh <- err
+		return
 	}
 	defer podLogs.Close()
+
+	// Start a goroutine to watch test status and provide periodic updates
+	go c.watchStatus(ctx, stream)
 
 	reader := bufio.NewScanner(podLogs)
 
@@ -112,7 +121,116 @@ func (c *Client) streamPodLogs(ctx context.Context, stream streamLogs) {
 	stream.doneCh <- true
 }
 
-// Tries to determine whether the ginkgo test suite has completed already. Returns false also in case streaming of logs fails over the period of a minute
+// parseTestProgress extracts test counts from logs by parsing spec counts and dot markers
+func parseTestProgress(logOutput string) (int, int, error) {
+	if logOutput == "" {
+		return 0, 0, fmt.Errorf("empty log output")
+	}
+
+	// Look for the line that shows how many tests will run
+	reStartLine := regexp.MustCompile(`Will run (0|[1-9]\d{0,3}|10000) of (0|[1-9]\d{0,3}|10000) specs`)
+	specs := reStartLine.FindStringSubmatch(logOutput)
+	if len(specs) < 2 {
+		return 0, 0, fmt.Errorf("could not find test spec count")
+	}
+
+	totalTests, err := strconv.Atoi(specs[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("error parsing total tests: %v", err)
+	}
+
+	// Extract substring after that line to count completed tests
+	loc := reStartLine.FindStringIndex(logOutput)
+	if loc == nil {
+		return totalTests, 0, fmt.Errorf("could not locate start line position")
+	}
+
+	substringAfter := logOutput[loc[1]:]
+
+	// Count all "•" characters in the substring
+	reDots := regexp.MustCompile(`•`)
+	dots := reDots.FindAllString(substringAfter, -1)
+	completedTests := len(dots)
+
+	return totalTests, completedTests, nil
+}
+
+// watchStatus monitors test progress by periodically checking e2e.log file in the pod
+func (c *Client) watchStatus(ctx context.Context, stream streamLogs) {
+	// Wait a bit for the container to start and create the log file
+	time.Sleep(5 * time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			cmd := []string{
+				"sh",
+				"-c",
+				"cat /tmp/results/e2e.log",
+			}
+			req := c.clientset.CoreV1().RESTClient().Post().
+				Resource("pods").
+				Name(conformance.PodName).
+				Namespace(c.namespace).
+				SubResource("exec").
+				Param("container", conformance.ConformanceContainer)
+
+			// Configure exec options
+			option := &corev1.PodExecOptions{
+				Stdout:  true,
+				Stderr:  true,
+				Command: cmd,
+			}
+			parameterCodec := scheme.ParameterCodec
+			req.VersionedParams(option, parameterCodec)
+
+			// Create an executor
+			exec, err := remotecommand.NewSPDYExecutor(c.config, "POST", req.URL())
+			if err != nil {
+				stream.doneCh <- true
+			}
+
+			// Stream the file content from the container
+			var stderr, stdout bytes.Buffer
+			err = exec.StreamWithContext(
+				ctx,
+				remotecommand.StreamOptions{
+					Stdout: &stdout,
+					Stderr: &stderr,
+				})
+			if err != nil {
+				stream.doneCh <- true
+			}
+
+			// Parse test progress
+			output := strings.TrimSpace(stdout.String())
+			totalTests, completedTests, err := parseTestProgress(output)
+			if err != nil {
+				stream.errCh <- err
+			}
+
+			// Send progress update
+			progressMsg := fmt.Sprintf("[%s] Progress: %d/%d tests completed (%.1f%%)\n",
+				time.Now().UTC().Format("15:04:05"),
+				completedTests,
+				totalTests,
+				float64(completedTests)/float64(totalTests)*100)
+			stream.logCh <- progressMsg
+
+			// If all tests are done, exit
+			if completedTests >= totalTests {
+				return
+			}
+
+			// Wait before checking again
+			time.Sleep(30 * time.Second)
+		}
+	}
+}
+
+// testsAreStillRunning tries to determine whether the ginkgo test suite has completed already. Returns false also in case streaming of logs fails over the period of a minute
 func (c *Client) testsAreStillRunning(ctx context.Context) bool {
 	reFinishedLine := regexp.MustCompile(`Ginkgo ran (00|[1-9]\d{0,2}) suite`)
 

--- a/pkg/conformance/client/logs_test.go
+++ b/pkg/conformance/client/logs_test.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseTestProgress tests the parseTestProgress function's ability to correctly count
+// completed tests from log output
+func TestParseTestProgress(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedTotal  int
+		expectedDone   int
+		expectError    bool
+		errorSubstring string
+	}{
+		{
+			name: "valid input with completed tests",
+			input: `
+I0402 12:34:56.789012      12 e2e.go:123] Starting e2e run "01234"
+I0402 12:34:57.789012      12 e2e.go:456] Will run 5 of 200 specs
+
+Kubernetes e2e suite
+=====================
+
+  SS•SS•SSS•SSSSSSSSSSSSSSS•SSSS
+`,
+			expectedTotal: 5,
+			expectedDone:  4,
+			expectError:   false,
+		},
+		{
+			name: "no completed tests yet",
+			input: `
+I0402 12:34:56.789012      12 e2e.go:123] Starting e2e run "01234"
+I0402 12:34:57.789012      12 e2e.go:456] Will run 10 of 200 specs
+
+Kubernetes e2e suite
+=====================
+
+  
+
+  Running tests...
+`,
+			expectedTotal: 10,
+			expectedDone:  0,
+			expectError:   false,
+		},
+		{
+			name: "all tests completed",
+			input: `
+I0402 12:34:56.789012      12 e2e.go:123] Starting e2e run "01234"
+I0402 12:34:57.789012      12 e2e.go:456] Will run 3 of 7 specs
+
+Kubernetes e2e suite
+=====================
+
+  S•S•S•S
+
+  Ran 3 of 7 specs
+`,
+			expectedTotal: 3,
+			expectedDone:  3,
+			expectError:   false,
+		},
+		{
+			name:           "empty input",
+			input:          "",
+			expectedTotal:  0,
+			expectedDone:   0,
+			expectError:    true,
+			errorSubstring: "empty log output",
+		},
+		{
+			name: "no test count line",
+			input: `
+I0402 12:34:56.789012      12 e2e.go:123] Starting e2e run "01234"
+
+Kubernetes e2e suite
+=====================
+
+  SS•SS•SSS•SSSSSSSSSSSSSSS•SSS
+
+  Ran 5 of 200 specs
+`,
+			expectedTotal:  0,
+			expectedDone:   0,
+			expectError:    true,
+			errorSubstring: "could not find test spec count",
+		},
+		{
+			name: "large number of tests",
+			input: `
+I0402 12:34:56.789012      12 e2e.go:123] Starting e2e run "01234"
+I0402 12:34:57.789012      12 e2e.go:456] Will run 1000 of 5000 specs
+
+Kubernetes e2e suite
+=====================
+
+  ` + generateDots(500) + `
+`,
+			expectedTotal: 1000,
+			expectedDone:  500,
+			expectError:   false,
+		},
+		{
+			name: "mixed success and skip markers",
+			input: `
+I0402 12:34:56.789012      12 e2e.go:123] Starting e2e run "01234"
+I0402 12:34:57.789012      12 e2e.go:456] Will run 15 of 50 specs
+
+Kubernetes e2e suite
+=====================
+
+  SSSS•SSSS•SSSS•SSSS•S
+`,
+			expectedTotal: 15,
+			expectedDone:  4,
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			total, done, err := parseTestProgress(tt.input)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorSubstring != "" {
+					assert.Contains(t, err.Error(), tt.errorSubstring)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedTotal, total, "Total test count does not match")
+				assert.Equal(t, tt.expectedDone, done, "Completed test count does not match")
+			}
+		})
+	}
+}
+
+// TestParseSpecificTestProgress tests the exact pattern requested in the original issue
+func TestParseSpecificTestProgress(t *testing.T) {
+	// Test specifically for the format provided in the request
+	input := `Will run 5 of 200 specs
+
+SS•SS•SSS•SSSSSSSSSSSSSSS•SSS
+
+`
+	total, done, err := parseTestProgress(input)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total, "Total test count does not match")
+	assert.Equal(t, 4, done, "Completed test count (dot characters) does not match")
+}
+
+// TestParseTestProgressEdgeCases tests edge cases and boundary conditions
+func TestParseTestProgressEdgeCases(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedTotal int
+		expectedDone  int
+		expectError   bool
+	}{
+		{
+			name: "zero tests to run",
+			input: `
+I0402 12:34:57.789012      12 e2e.go:456] Will run 0 of 200 specs
+`,
+			expectedTotal: 0,
+			expectedDone:  0,
+			expectError:   false,
+		},
+		{
+			name: "maximum boundary test count",
+			input: `
+I0402 12:34:57.789012      12 e2e.go:456] Will run 10000 of 10000 specs
+`,
+			expectedTotal: 10000,
+			expectedDone:  0,
+			expectError:   false,
+		},
+		{
+			name: "malformed spec count",
+			input: `
+I0402 12:34:57.789012      12 e2e.go:456] Will run abc of 200 specs
+`,
+			expectedTotal: 0,
+			expectedDone:  0,
+			expectError:   true,
+		},
+		{
+			name: "dots before spec count line",
+			input: `
+••••••••••
+I0402 12:34:57.789012      12 e2e.go:456] Will run 5 of 200 specs
+
+SS•SS•
+`,
+			expectedTotal: 5,
+			expectedDone:  2,
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			total, done, err := parseTestProgress(tt.input)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedTotal, total, "Total test count does not match")
+				assert.Equal(t, tt.expectedDone, done, "Completed test count does not match")
+			}
+		})
+	}
+}
+
+// generateDots is a helper function to generate a string with n dot characters
+func generateDots(n int) string {
+	dots := make([]rune, n)
+	for i := range dots {
+		dots[i] = '•'
+	}
+	return string(dots)
+}

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -48,19 +48,23 @@ type Configuration struct {
 	DryRun           bool          `yaml:"dryRun"`
 	TestRepoList     string        `yaml:"testRepoList"`
 	TestRepo         string        `yaml:"testRepo"`
-	ExtraArgs        []string      `yaml:"extraArgs"`
-	ExtraGinkgoArgs  []string      `yaml:"extraGinkgoArgs"`
-	StartupTimeout   time.Duration `yaml:"startupTimeout"`
+	ExtraArgs              []string      `yaml:"extraArgs"`
+	ExtraGinkgoArgs        []string      `yaml:"extraGinkgoArgs"`
+	StartupTimeout         time.Duration `yaml:"startupTimeout"`
+	DisableProgressStatus  bool          `yaml:"disableProgressStatus"`
+	ProgressStatusInterval time.Duration `yaml:"progressStatusInterval"`
 }
 
 func NewDefaultConfiguration() Configuration {
 	return Configuration{
-		Parallel:       1,
-		Verbosity:      4,
-		OutputDir:      ".",
-		BusyboxImage:   DefaultBusyboxImage,
-		Namespace:      DefaultNamespace,
-		StartupTimeout: 5 * time.Minute,
+		Parallel:               1,
+		Verbosity:              4,
+		OutputDir:              ".",
+		BusyboxImage:           DefaultBusyboxImage,
+		Namespace:              DefaultNamespace,
+		StartupTimeout:         5 * time.Minute,
+		DisableProgressStatus:  false,
+		ProgressStatusInterval: 30 * time.Second,
 	}
 }
 


### PR DESCRIPTION
Implements progress tracking by calculating percentage based on processed vs total test count to output logs during test execution

Periodically reads e2e.log from conformance pod via k8s exec API every 30 seconds

Original inspiration from @rjsadow work on progress indicator -- https://github.com/kubernetes-sigs/hydrophone/pull/225

Resolves #223 
```

14:39:35 INF API endpoint: https://127.0.0.1:6443
14:39:35 INF Server version: version.Info{Major:"1", Minor:"31", GitVersion:"v1.31.5+k3s1", GitCommit:"56ec5dd4d012c1d77dc7f50f21f65183044c92e7", GitTreeState:"clean", BuildDate:"2025-01-28T17:45:21Z", GoVersion:"go1.22.10", Compiler:"gc", Platform:"linux/amd64"}
14:39:35 INF Using namespace: conformance
14:39:35 INF Using conformance image: registry.k8s.io/conformance:v1.31.5
14:39:35 INF Using busybox image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
14:39:35 INF Test framework will start 1 thread(s) and use verbosity level 4.
14:39:35 INF Created namespace conformance.
14:39:35 INF Created ServiceAccount conformance-serviceaccount.
14:39:35 INF Created ClusterRole conformance-serviceaccount:conformance.
14:39:35 INF Created ClusterRoleBinding conformance-serviceaccount-role:conformance.
14:39:35 INF Created Pod e2e-conformance-test.
14:39:35 INF Waiting up to 5m0s for Pod to start...
14:39:36 INF Created ConformancePod e2e-conformance-test.
2025/04/02 14:39:36 Running command:
Command env: []
Run from directory: 
Executable path: /usr/local/bin/ginkgo
Args (comma-delimited): /usr/local/bin/ginkgo,--focus=\[Conformance\],--skip=,--no-color=true,--timeout=24h,/usr/local/bin/e2e.test,--,--disable-log-dump,--repo-root=/kubernetes,--provider=skeleton,--report-dir=/tmp/results,--kubeconfig=
2025/04/02 14:39:36 Now listening for interrupts
  I0402 14:39:36.721627      24 e2e.go:109] Starting e2e run "68a87f29-c011-4b98-93bc-4e6ecc16f28e" on Ginkgo node 1
Running Suite: Kubernetes e2e suite - /usr/local/bin
====================================================
Random Seed: 1743604776 - will randomize all specs

Will run 404 of 6605 specs
[14:39:41] Progress: 1/404 tests completed (0.2%)
[14:40:11] Progress: 7/404 tests completed (1.7%)
[14:40:41] Progress: 11/404 tests completed (2.7%)
[14:41:11] Progress: 19/404 tests completed (4.7%)
```
Completed hour long conformance test 

```
[16:19:53] Progress: 389/404 tests completed (96.3%)
[16:20:23] Progress: 389/404 tests completed (96.3%)
[16:20:53] Progress: 389/404 tests completed (96.3%)
[16:21:23] Progress: 389/404 tests completed (96.3%)
[16:21:53] Progress: 389/404 tests completed (96.3%)
[16:22:23] Progress: 393/404 tests completed (97.3%)
[16:22:53] Progress: 393/404 tests completed (97.3%)
[16:23:23] Progress: 393/404 tests completed (97.3%)
[16:23:53] Progress: 396/404 tests completed (98.0%)
[16:24:23] Progress: 400/404 tests completed (99.0%)
SSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSS•SSSSSSSSSSS•SSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSS•SSSS•SSS•SSSSSSSSSSSSSSSSSSSSSSS•S•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSS••SS•SSSS•SSS•SSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSS•SS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•S•SSSSSSSSSSSSS•S•SS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS••SSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSS•SSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSS•SSS••SSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSS•SSS•SSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSS•SS

Summarizing 3 Failures:
  [FAIL] [sig-architecture] Conformance Tests [It] should have at least two untainted nodes [Conformance] [sig-architecture, Conformance]
  k8s.io/kubernetes/test/e2e/architecture/conformance.go:45
  [FAIL] [sig-api-machinery] Servers with support for API chunking [It] should support continue listing from the last key if the original version has been compacted away, though the list is inconsistent [Slow] [Conformance] [sig-api-machinery, Slow, Conformance]
  k8s.io/kubernetes/test/e2e/apimachinery/chunking.go:202
  [FAIL] [sig-apps] Daemon set [Serial] [It] should rollback without unnecessary restarts [Conformance] [sig-apps, Serial, Conformance]
  k8s.io/kubernetes/test/e2e/apps/daemon_set.go:446

Ran 404 of 6605 Specs in 6293.100 seconds
FAIL! -- 401 Passed | 3 Failed | 0 Pending | 6201 Skipped
--- FAIL: TestE2E (6293.24s)
FAIL

Ginkgo ran 1 suite in 1h44m53.537715399s

Test Suite Failed
2025/04/02 16:24:29 Saving results at /tmp/results
2025/04/02 16:24:30 running command: exit status 1
16:24:31 INF Tests finished after 1h44m54s.
16:24:31 INF Downloading e2e.log to e2e.log...
16:24:31 INF Downloading junit_01.xml to junit_01.xml...
16:24:31 INF Waiting for Pod to terminate...
16:24:31 INF Container conformance-container terminated.
16:24:31 INF Deleted ClusterRoleBinding conformance-serviceaccount-role:conformance.
16:24:31 INF Deleted ClusterRole conformance-serviceaccount:conformance.
16:24:31 INF Waiting for Namespace conformance to be deleted.
16:25:13 INF Deleted Namespace conformance.
16:25:13 ERR Tests failed (code 1).

```

