### PR TITLE
fix(pkg/conformance/client): v0.7.0 - nil pointer panic in streamPodLogs

### DIFF
--- a/pkg/conformance/client/logs.go
+++ b/pkg/conformance/client/logs.go
@@ -58,7 +58,12 @@ func (c *Client) PrintE2ELogs(ctx context.Context) error {
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	for {
-		pod, _ := podInformer.Lister().Pods(c.namespace).Get(conformance.PodName)
+		pod, err := podInformer.Lister().Pods(c.namespace).Get(conformance.PodName)
+		if err != nil {
+			log.Errorf("Waiting for pod %s/%s to be created: %v", c.namespace, conformance.PodName, err)
+			time.Sleep(time.Second)
+			continue
+		}
 		if pod.Status.Phase == corev1.PodRunning {
 			var err error
 			stream := streamLogs{

--- a/pkg/conformance/client/logs_test.go
+++ b/pkg/conformance/client/logs_test.go
@@ -237,3 +237,8 @@ func generateDots(n int) string {
 	}
 	return string(dots)
 }
+
+func TestParseTestProgressEmpty(t *testing.T) {
+	_, _, err := parseTestProgress("")
+	assert.Error(t, err)
+}


### PR DESCRIPTION

**What this PR does / why we need it**:

pod log stream returns nil (pod containers not yet ready / log stream not available) and the code doesn't nil-check before using it. The panic leaves stale Kubernetes resources behind (ClusterRole, ClusterRoleBinding, ServiceAccount, Namespace), causing subsequent runs to fail with "ClusterRole already exist, please run --cleanup first"

Workaround: run hydrophone --kubeconfig <path> --cleanup before the test.

**Which issue(s) this PR fixes**

Reproduction Steps

1. Install hydrophone v0.7.0: go install sigs.k8s.io/hydrophone@latest
2. Run conformance tests with --parallel 1 against a cluster
3. Panic occurs immediately after the conformance pod starts (within ~8 seconds of pod creation)

Timeline from logs

```
06:41:26 INF API endpoint: https://100.64.0.1:6443
06:41:26 INF Server version: v1.35.0
06:41:26 INF Using namespace: conformance
06:41:26 INF Focus: \[Conformance\]
06:41:26 INF Skipping tests: <pattern>
06:41:26 INF Test framework will start 1 thread(s) and use verbosity level 6.
06:41:26 INF Created namespace conformance.
06:41:26 INF Created ServiceAccount conformance-serviceaccount.
06:41:26 INF Created ClusterRole conformance-serviceaccount:conformance.
06:41:26 INF Created ClusterRoleBinding conformance-serviceaccount-role:conformance.
06:41:27 INF Created Pod e2e-conformance-test.
06:41:27 INF Waiting up to 5m0s for Pod to start...
06:41:35 INF Created ConformancePod e2e-conformance-test.
```

Panic Stack Trace

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x197c745]

goroutine 34 [running]:
sigs.k8s.io/hydrophone/pkg/conformance/client.(*Client).streamPodLogs(0xc0003cec60, {0x22606c8, 0x33dba60}, {0xc0001a49a0?, 0xc0001a4a10?, 0xc0001a4a80?})
      /var/folders/6j/x4l4v3_n7cx5xr5z4j1myc540000gn/T/hydrophone-gopath-43402371/pkg/mod/sigs.k8s.io/hydrophone@v0.7.0/pkg/conformance/client/logs.go:104 +0x145
created by sigs.k8s.io/hydrophone/pkg/conformance/client.(*Client).PrintE2ELogs in goroutine 1
      /var/folders/6j/x4l4v3_n7cx5xr5z4j1myc540000gn/T/hydrophone-gopath-43402371/pkg/mod/sigs.k8s.io/hydrophone@v0.7.0/pkg/conformance/client/logs.go:65 +0x2e6
```

**Special notes for your reviewer**:

```
Version: sigs.k8s.io/hydrophone@v0.7.0
Go module path: sigs.k8s.io/hydrophone@v0.7.0/pkg/conformance/client/logs.go
Kubernetes: v1.35.0
Platform: linux/amd64
```
