### PR TITLE
security: Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout hydrophone
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version: '1.24.2'
 
@@ -33,7 +33,7 @@ jobs:
 
       - name: Create PR
         if: ${{ steps.update_deps.outputs.changes != '' }}
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5  # v5.0.3
         with:
           title: 'Update to latest Kubernetes dependencies'
           commit-message: Update to latest Kubernetes dependencies

--- a/.github/workflows/weekly-trivy-scan.yml
+++ b/.github/workflows/weekly-trivy-scan.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 1
           


### PR DESCRIPTION
## Summary

The kubernetes-sigs org policy requires all GitHub Actions to be pinned to a full-length commit SHA. Both the **Update Dependencies** and **Weekly Trivy Scan** workflows have been failing on every scheduled run with:

> The action `<action>@<tag>` is not allowed in kubernetes-sigs/hydrophone because all actions must be pinned to a full-length commit SHA.

This PR pins the remaining unpinned actions:

- `actions/checkout@v4` → `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
- `actions/setup-go@v5` → `40f1582b2485089dde7abd97c1529aa768e1baff` (v5.6.0)
- `peter-evans/create-pull-request@v5` → `4e1beaa7521e8b457b572c090b25bd3db56bf1c5` (v5.0.3)

Follows the same SHA-pinning pattern already used for `aquasecurity/trivy-action` in commit addfd54.