### PR TITLE
ci: fix update-deps workflow (dl.k8s.io + Node.js 24 actions)

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout hydrophone
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: '1.24.2'
 

--- a/.github/workflows/weekly-trivy-scan.yml
+++ b/.github/workflows/weekly-trivy-scan.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
           

--- a/hack/bump-k8s.sh
+++ b/hack/bump-k8s.sh
@@ -23,7 +23,7 @@ pushd "${HYDROPHONE_ROOT}" >/dev/null
   go mod edit -json | jq -r ".Require[] | .Path | select(contains(\"k8s.io/\"))" | xargs -L1 go get -d
   go mod tidy
 
-  K8S_VERSION=$(curl https://cdn.dl.k8s.io/release/stable.txt -s)
+  K8S_VERSION=$(curl https://dl.k8s.io/release/stable.txt -s)
   sed -i "s|K8S_VERSION: .*|K8S_VERSION: $K8S_VERSION|" .github/workflows/*.yml
   sed -i -r "s/conformance:v[0-9]+\.[0-9]+\.[0-9]+/conformance:$K8S_VERSION/g" README.md pkg/common/*.go
 


### PR DESCRIPTION
## Summary

Fixes two issues observed in [actions run 25981733542](https://github.com/kubernetes-sigs/hydrophone/actions/runs/25981733542/job/76371599517):

- **`hack/bump-k8s.sh`** — use `https://dl.k8s.io/release/stable.txt` instead of `https://cdn.dl.k8s.io/...`. The CDN host failed with `curl` exit code 6 in the runner, which broke the nightly dependency-bump job.
- **GitHub Actions on Node.js 20 deprecation** — bump `actions/checkout` to `v6.0.2` and `actions/setup-go` to `v6.4.0`. Both now run on Node.js 24, clearing the deprecation warning ahead of the June 2nd, 2026 cutoff. SHAs remain pinned per the convention from #299.
