### PR TITLE
ci: read Go version from go.mod in update-deps workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
-          go-version: '1.24.2'
+          go-version-file: 'go.mod'
 
       - name: Update Dependencies
         id: update_deps


### PR DESCRIPTION
## Summary

- The `update-deps` workflow pinned Go to `1.24.2`, but `go.mod` requires `go >= 1.25.0`. This caused every `go get` invocation in `hack/bump-k8s.sh` to fail with `go: go.mod requires go >= 1.25.0 (running go 1.24.2; GOTOOLCHAIN=local)`, exiting the step with code 123 ([failed run](https://github.com/kubernetes-sigs/hydrophone/actions/runs/25982195932/job/76372801909)).
- Switch `actions/setup-go` to `go-version-file: 'go.mod'` so the workflow tracks `go.mod` automatically and won't drift again on future Go bumps.