### PR TITLE
go.mod: bump go directive to 1.26.0 (+ Dockerfile)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/hydrophone
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -23,7 +23,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 cd "${KUBE_ROOT}"
 
 LINT=${LINT:-golangci-lint}
-VERSION=2.8.0
+VERSION=2.12.2
 
 if [[ -z "$(command -v ${LINT})" ]]; then
   echo "${LINT} is missing. Installing it now..."


### PR DESCRIPTION
## Summary

- Latest k8s.io modules now require `go >= 1.26.0`, e.g. `k8s.io/api@v0.36.1`. The `update-deps` workflow (which reads `go-version-file: 'go.mod'`) currently provisions Go 1.25.0 and fails with `go: k8s.io/api@v0.36.1 requires go >= 1.26.0 (running go 1.25.0; GOTOOLCHAIN=local)` ([failed run](https://github.com/kubernetes-sigs/hydrophone/actions/runs/25982613720/job/76373960955)).
- Bump the `go` directive in `go.mod` from `1.25.0` to `1.26.0` so `hack/bump-k8s.sh` can pull the current `k8s.io/*` releases. With `go-version-file` in place, the workflow automatically picks up the new version.
- Also bump the `builder` stage in `Dockerfile` from `golang:1.24-alpine` to `golang:1.26-alpine` to keep the container build aligned and avoid forcing a toolchain download at image-build time.