### PR TITLE
ci: bump peter-evans/create-pull-request to v8.1.1

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Create PR
         if: ${{ steps.update_deps.outputs.changes != '' }}
-        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5  # v5.0.3
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           title: 'Update to latest Kubernetes dependencies'
           commit-message: Update to latest Kubernetes dependencies


### PR DESCRIPTION
## Summary

- The `Create PR` step in `update-deps` workflow fails on current GitHub-hosted runners with `remote: Duplicate header: \"Authorization\"` / `git failed with exit code 128` ([failed run](https://github.com/kubernetes-sigs/hydrophone/actions/runs/25991707493/job/76398941996)).
- The pinned action `peter-evans/create-pull-request@v5.0.3` also triggers the Node.js 20 deprecation warning (forced-to-Node-24 cutover on 2026-06-02).
- Bump to `v8.1.1` (`5f6978faf089d4d20b00c7766989d076bb2fc7f1`), which runs on Node 24 and contains the upstream fix for the duplicate Authorization header against newer git. Pinned to the full-length commit SHA per the existing action-pinning policy.
- Inputs used by the step (`title`, `commit-message`, `branch`, `base`, `labels`, etc.) are stable across v5 → v8 and need no changes.

## Test plan

- [ ] Manually dispatch the `Update Dependencies` workflow on this branch (will require merge first or a fork-side dispatch) and confirm the `Create PR` step completes successfully without git or Node deprecation errors.