### PR TITLE
Bump example conformance-image tags to v1.37.0

### DIFF
--- a/docs/air-gapped.md
+++ b/docs/air-gapped.md
@@ -39,7 +39,7 @@ Once the image is created we will need to populate it with the images required f
 We can do this by pulling the images, re-tagging them, and pushing them to the internal registry.
 
 ```bash
-$ for image in `hydrophone --list-images && echo registry.k8s.io/conformance:v1.29.0 && echo registry.k8s.io/e2e-test-images/busybox:1.36.1-1`; do
+$ for image in `hydrophone --list-images && echo registry.k8s.io/conformance:v1.37.0 && echo registry.k8s.io/e2e-test-images/busybox:1.36.1-1`; do
     docker pull $image;
     docker tag $image `echo $image | sed -E 's#^[^/]+/#127.0.0.1:5001/#'`;
     docker push `echo $image | sed -E 's#^[^/]+/#127.0.0.1:5001/#'`;
@@ -80,7 +80,7 @@ Now we can use Hydrophone to run the entire conformance suite with the following
 ```bash
 $ hydrophone \
     --conformance \
-    --conformance-image localhost:5001/conformance:v1.29.0 \
+    --conformance-image localhost:5001/conformance:v1.37.0 \
     --busybox-image localhost:5001/e2e-test-images/busybox:1.36.1-1 \
     --test-repo-list $REG_CONFIG
 ```

--- a/docs/ci-cd-integration-guide.md
+++ b/docs/ci-cd-integration-guide.md
@@ -36,7 +36,7 @@ jobs:
           KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
 
       - name: Run Hydrophone (dry run)
-        run: hydrophone --conformance --conformance-image registry.k8s.io/conformance:v1.34.0 --timeout 5m --dry-run
+        run: hydrophone --conformance --conformance-image registry.k8s.io/conformance:v1.37.0 --timeout 5m --dry-run
 ```
 
 **Notes:**
@@ -61,7 +61,7 @@ hydrophone-conformance:
   script:
     - go install sigs.k8s.io/hydrophone@latest
     - echo "$KUBE_CONFIG_DATA" | base64 -d > ~/.kube/config
-    - hydrophone --conformance --conformance-image registry.k8s.io/conformance:v1.34.0 --timeout 10m
+    - hydrophone --conformance --conformance-image registry.k8s.io/conformance:v1.37.0 --timeout 10m
   only:
     - main
 ```
@@ -88,7 +88,7 @@ pipeline {
             steps {
                 sh 'go install sigs.k8s.io/hydrophone@latest'
                 sh 'echo $KUBE_CONFIG_DATA | base64 -d > $HOME/.kube/config'
-                sh 'hydrophone --conformance --conformance-image registry.k8s.io/conformance:v1.34.0 --timeout 10m'
+                sh 'hydrophone --conformance --conformance-image registry.k8s.io/conformance:v1.37.0 --timeout 10m'
             }
         }
     }
@@ -121,7 +121,7 @@ periodics:
       - |
         go install sigs.k8s.io/hydrophone@latest
         echo "$KUBE_CONFIG_DATA" | base64 -d > /root/.kube/config
-        hydrophone --conformance --conformance-image registry.k8s.io/conformance:v1.34.0 --timeout 10m
+        hydrophone --conformance --conformance-image registry.k8s.io/conformance:v1.37.0 --timeout 10m
       env:
       - name: KUBE_CONFIG_DATA
         valueFrom:


### PR DESCRIPTION
## Summary
- The k8s 1.37 update (#309) bumped go.mod deps and the README example but missed two docs.
- Update example `--conformance-image` tags in `docs/ci-cd-integration-guide.md` (v1.34.0) and `docs/air-gapped.md` (v1.29.0) to v1.37.0.

## Test plan
- [x] Docs-only change, no build impact.