### PR TITLE
Migrate .goreleaser.yaml to v2 schema

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
-version: 1
+version: 2
 
 before:
   hooks:
@@ -32,7 +32,7 @@ builds:
         goarch: arm64
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -44,7 +44,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary
- `goreleaser check` fails against currently-shipping goreleaser v2.x: `only version: 2 configuration files are supported, yours is version: 1`.
- Rename `archives.format` / `archives.format_overrides.format` to the v2 `formats: [...]` list form.
- No release automation exists in this repo (releases are cut by a maintainer running `goreleaser release` locally after tagging), so this was silently broken for anyone using a current goreleaser install.

## Test plan
- [x] `goreleaser check` passes.
- [x] `goreleaser release --snapshot --clean` cross-builds all target platforms (darwin/linux amd64+arm64, linux ppc64le/s390x, windows amd64) successfully.